### PR TITLE
Added a non-interfering serialization call to any_regular_t that calls operator<<(std::ostream&, T&) only when it is defined.

### DIFF
--- a/adobe/any_regular.hpp
+++ b/adobe/any_regular.hpp
@@ -32,12 +32,13 @@
 #include <adobe/empty.hpp>
 #include <adobe/memory.hpp>
 #include <adobe/regular_concept.hpp>
+#include <adobe/serializable.hpp>
 #include <adobe/typeinfo.hpp>
 
 #include <adobe/implementation/swap.hpp>
 
 #if defined(ADOBE_STD_SERIALIZATION)
-#include <iosfwd>
+#include <adobe/iomanip.hpp>
 #endif
 
 /**************************************************************************************************/
@@ -156,8 +157,10 @@ const
 namespace implementation {
 
 enum {
-    vtable_version = 1
+    vtable_version = 2
 };
+
+/**************************************************************************************************/
 
 struct any_regular_interface_t;
 
@@ -172,11 +175,12 @@ struct vtable_t {
     void (*assign)(interface_type&, const interface_type&);
     bool (*equals)(const interface_type&, const interface_type&);
     void (*exchange)(interface_type&, interface_type&);
+    void (*serialize)(const interface_type&, std::ostream&);
 };
 
 // Ensure that the vtable_t has a fixed layout regardless of alignment or packing.
 
-BOOST_STATIC_ASSERT(sizeof(vtable_t) == 8 * sizeof(void*));
+BOOST_STATIC_ASSERT(sizeof(vtable_t) == 9 * sizeof(void*));
 
 /**************************************************************************************************/
 
@@ -203,6 +207,7 @@ struct any_regular_interface_t {
     void assign(const interface_type& x) { object_m.vtable_m->assign(*this, x); }
     bool equals(const interface_type& x) const { return object_m.vtable_m->equals(*this, x); }
     void exchange(interface_type& x) { object_m.vtable_m->exchange(*this, x); }
+    void serialize(std::ostream& s) const { object_m.vtable_m->serialize(*this, s); }
 };
 
 /**************************************************************************************************/
@@ -251,6 +256,10 @@ struct any_regular_model_local : any_regular_interface_t, boost::noncopyable {
         swap(self(x).object_m, self(y).object_m);
     }
 
+    static void serialize(const interface_type& x, std::ostream& s) {
+        s << format(self(x).get());
+    }
+
     const T& get() const { return object_m; }
     T& get() { return object_m; }
 };
@@ -262,7 +271,8 @@ const vtable_t any_regular_model_local<T>::vtable_s = {
     vtable_version,                       &any_regular_model_local::destruct,
     &any_regular_model_local::type_info,  &any_regular_model_local::clone,
     &any_regular_model_local::move_clone, &any_regular_model_local::assign,
-    &any_regular_model_local::equals,     &any_regular_model_local::exchange, };
+    &any_regular_model_local::equals,     &any_regular_model_local::exchange,
+    &any_regular_model_local::serialize, };
 
 template <typename T> // T models Regular
 struct any_regular_model_remote : any_regular_interface_t, boost::noncopyable {
@@ -338,6 +348,10 @@ struct any_regular_model_remote : any_regular_interface_t, boost::noncopyable {
         return swap(self(x).object_ptr_m, self(y).object_ptr_m);
     }
 
+    static void serialize(const interface_type& x, std::ostream& s) {
+        s << format(self(x).get());
+    }
+
     const T& get() const { return object_ptr_m->data_m; }
     T& get() { return object_ptr_m->data_m; }
 };
@@ -349,7 +363,8 @@ const vtable_t any_regular_model_remote<T>::vtable_s = {
     vtable_version,                        &any_regular_model_remote::destruct,
     &any_regular_model_remote::type_info,  &any_regular_model_remote::clone,
     &any_regular_model_remote::move_clone, &any_regular_model_remote::assign,
-    &any_regular_model_remote::equals,     &any_regular_model_remote::exchange, };
+    &any_regular_model_remote::equals,     &any_regular_model_remote::exchange,
+    &any_regular_model_remote::serialize, };
 
 /**************************************************************************************************/
 
@@ -483,7 +498,7 @@ public:
     */
 
     template <typename T>
-    any_regular_t(T x) {
+    explicit any_regular_t(T x) {
         ::new (storage()) typename traits<T>::model_type(std::move(x));
     }
 
@@ -583,7 +598,12 @@ public:
     };
 
 #if defined(ADOBE_STD_SERIALIZATION)
-    friend std::ostream& operator<<(std::ostream& out, const any_regular_t& value);
+    friend std::ostream& operator<<(std::ostream& out, const any_regular_t& value)
+    {
+        value.object().serialize(out);
+
+        return out;
+    }
 #endif
 
     friend bool operator==(const any_regular_t& x, const any_regular_t& y);

--- a/adobe/array.hpp
+++ b/adobe/array.hpp
@@ -46,7 +46,7 @@ inline std::ostream& operator<<(std::ostream& out, const array_t& x) {
     out << begin_sequence;
 
     for (const auto& e : x)
-        out << format(e);
+        out << e; // format will be called by any_regular_t.
 
     out << end_sequence;
 

--- a/adobe/iomanip.hpp
+++ b/adobe/iomanip.hpp
@@ -223,8 +223,10 @@ public:
 private:
     static stream_type& fct(stream_type& os, const argument_type& i) {
         format_base* format(get_formatter(os));
+
         if (format)
             format->begin_bag(os, i);
+
         return os;
     }
 };

--- a/adobe/iomanip.hpp
+++ b/adobe/iomanip.hpp
@@ -24,7 +24,7 @@
 #include <stdexcept>
 #include <functional>
 
-#include <adobe/any_regular.hpp>
+#include <adobe/serializable.hpp>
 #include <adobe/iomanip_fwd.hpp>
 #include <adobe/manip.hpp>
 #include <adobe/name.hpp>
@@ -61,12 +61,12 @@ public:
     explicit format_element_t(name_t tag = name_t(), const std::string& ident = std::string())
         : ident_m(ident), num_out_m(0), tag_m(tag), value_m(0) {}
 
-    format_element_t(name_t tag, const any_regular_t& value)
+    format_element_t(name_t tag, const serializable_t& value)
         : num_out_m(0), tag_m(tag), value_m(&value) {}
 
     name_t tag() const { return tag_m; }
 
-    const any_regular_t& value() const {
+    const serializable_t& value() const {
         if (!value_m)
             throw std::runtime_error("invalid value");
 
@@ -78,7 +78,7 @@ public:
 
 private:
     name_t tag_m;
-    const any_regular_t* value_m;
+    const serializable_t* value_m;
 };
 
 /*************************************************************************************************/
@@ -104,7 +104,7 @@ public:
     virtual void begin_alternate(stream_type& os) { push_stack(os); }
     virtual void end_alternate(stream_type& os) { pop_stack(os); }
 
-    virtual void begin_atom(stream_type& os, const any_regular_t&) { push_stack(os); }
+    virtual void begin_atom(stream_type& os, const serializable_t&) { push_stack(os); }
     virtual void end_atom(stream_type& os) { pop_stack(os); }
 
     format_base() : depth_m(0) {}
@@ -233,14 +233,14 @@ private:
 
 //!\ingroup manipulator
 template <typename T>
-class begin_atom : public basic_omanipulator<const any_regular_t, char, std::char_traits<char>> {
-    typedef basic_omanipulator<const any_regular_t, char, std::char_traits<char>> inherited_t;
+class begin_atom : public basic_omanipulator<const serializable_t, char, std::char_traits<char>> {
+    typedef basic_omanipulator<const serializable_t, char, std::char_traits<char>> inherited_t;
 
 public:
     typedef inherited_t::stream_type stream_type;
     typedef inherited_t::argument_type argument_type;
 
-    explicit begin_atom(const T& x) : inherited_t(begin_atom::fct, any_regular_t(x)) {}
+    explicit begin_atom(const T& x) : inherited_t(begin_atom::fct, serializable_t(x)) {}
 
     inherited_t& operator()(argument_type /*i*/) { return *this; }
 
@@ -248,10 +248,10 @@ private:
     static stream_type& fct(stream_type& os, const argument_type& atom) {
         format_base* format(get_formatter(os));
 
-        if (format == 0)
-            return os << atom.cast<typename promote<T>::type>();
-
-        format->begin_atom(os, atom);
+        if (format)
+            format->begin_atom(os, atom);
+        else
+            os << atom;
 
         return os;
     }

--- a/adobe/iomanip_asl_cel.hpp
+++ b/adobe/iomanip_asl_cel.hpp
@@ -39,7 +39,7 @@ public:
 
     virtual void begin_sequence(stream_type& os);
 
-    virtual void begin_atom(stream_type& os, const any_regular_t&);
+    virtual void begin_atom(stream_type& os, const serializable_t&);
 
 private:
     virtual void stack_event(stream_type& os, bool is_push);

--- a/adobe/iomanip_javascript.hpp
+++ b/adobe/iomanip_javascript.hpp
@@ -37,7 +37,7 @@ public:
 
     virtual void begin_sequence(stream_type& os);
 
-    virtual void begin_atom(stream_type& os, const any_regular_t&);
+    virtual void begin_atom(stream_type& os, const serializable_t&);
 
 private:
     virtual void stack_event(stream_type& os, bool is_push);

--- a/adobe/iomanip_pdf.hpp
+++ b/adobe/iomanip_pdf.hpp
@@ -37,7 +37,7 @@ public:
 
     virtual void begin_sequence(stream_type& os);
 
-    virtual void begin_atom(stream_type& os, const any_regular_t&);
+    virtual void begin_atom(stream_type& os, const serializable_t&);
 
 private:
     virtual void stack_event(stream_type& os, bool is_push);

--- a/adobe/iomanip_xml.hpp
+++ b/adobe/iomanip_xml.hpp
@@ -37,7 +37,7 @@ public:
 
     virtual void begin_sequence(stream_type& os);
 
-    virtual void begin_atom(stream_type& os, const any_regular_t&);
+    virtual void begin_atom(stream_type& os, const serializable_t&);
 
 private:
     virtual void stack_event(stream_type& os, bool is_push);

--- a/adobe/json.hpp
+++ b/adobe/json.hpp
@@ -78,6 +78,7 @@ class json_parser {
 
   private:    
     bool is_object(value_type& t) {
+        using std::move;
         if (!is_structural_char('{')) return false;
         object_type object;
         key_type string;
@@ -100,6 +101,7 @@ class json_parser {
     }
     
     bool is_array(value_type& t) {
+        using std::move;
         if (!is_structural_char('[')) return false;
         array_type array;
         value_type value;
@@ -178,6 +180,7 @@ class json_parser {
     }
     
     bool is_string(value_type& t) {
+        using std::move;
         string_type string;
         bool result = is_string(string);
         if (result) t = move(string);

--- a/adobe/json.hpp
+++ b/adobe/json.hpp
@@ -78,7 +78,6 @@ class json_parser {
 
   private:    
     bool is_object(value_type& t) {
-        using std::move;
         if (!is_structural_char('{')) return false;
         object_type object;
         key_type string;
@@ -96,12 +95,11 @@ class json_parser {
             }
         }
         require(is_structural_char('}'), "}");
-        t = move(object);
+        t = value_type(move(object));
         return true;
     }
     
     bool is_array(value_type& t) {
-        using std::move;
         if (!is_structural_char('[')) return false;
         array_type array;
         value_type value;
@@ -113,7 +111,7 @@ class json_parser {
             }
         }
         require(is_structural_char(']'), "]");
-        t = move(array);
+        t = value_type(move(array));
         return true;
     }
     
@@ -139,8 +137,8 @@ class json_parser {
     }
     
     bool is_bool(value_type& t) {
-        if (is_sequence("true")) { t = true; return true; }
-        if (is_sequence("false")) { t = false; return true; }
+        if (is_sequence("true")) { t = value_type(true); return true; }
+        if (is_sequence("false")) { t = value_type(false); return true; }
         return false;
     }
     
@@ -180,10 +178,10 @@ class json_parser {
     }
     
     bool is_string(value_type& t) {
-        using std::move;
         string_type string;
         bool result = is_string(string);
-        if (result) t = move(string);
+        if (result)
+            t = value_type(move(string));
         return result;
     }
 
@@ -203,7 +201,7 @@ class json_parser {
         require(std::isfinite(value), "finite number");
         ADOBE_ASSERT(count == p_ - p && "StringToDouble() failure");
 
-        t = value;
+        t = value_type(value);
         return true;
     }
     

--- a/adobe/serializable.hpp
+++ b/adobe/serializable.hpp
@@ -1,0 +1,189 @@
+/*
+    Copyright 2013 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+/*************************************************************************************************/
+
+#ifndef ADOBE_SERIALIZABLE_HPP
+#define ADOBE_SERIALIZABLE_HPP
+
+#include <adobe/config.hpp>
+
+#include <type_traits>
+#include <ostream>
+
+#include <double-conversion/src/double-conversion.h>
+
+#include <adobe/typeinfo.hpp>
+
+/*************************************************************************************************/
+
+namespace adobe {
+
+/**************************************************************************************************/
+
+namespace implementation {
+
+/**************************************************************************************************/
+
+template <class>
+struct sfinae_true : std::true_type {};
+
+// test_stream_insertion is a modification of http://stackoverflow.com/a/9154394
+
+template <class T, class Stream>
+static auto test_stream_insertion(int) ->
+    sfinae_true<decltype(std::declval<Stream>() << std::declval<T>())>;
+
+template<class, class>
+static auto test_stream_insertion(long) -> std::false_type;
+
+/*************************************************************************************************/
+
+} // namespace implementation
+
+/*************************************************************************************************/
+
+template <class T, class Stream>
+struct has_stream_insertion : decltype(implementation::test_stream_insertion<T, Stream>(0)) {};
+
+template <class T>
+using has_ostream_insertion = has_stream_insertion<T, std::ostream&>;
+
+/*************************************************************************************************/
+
+template <class T>
+inline typename std::enable_if<has_ostream_insertion<T>::value>::type
+ostream_insertion(std::ostream& s, const T& x) {
+    s << x;
+}
+
+template <class T>
+inline typename std::enable_if<!has_ostream_insertion<T>::value>::type
+ostream_insertion(std::ostream&, const T&) {}
+
+template <>
+inline void ostream_insertion<bool>(std::ostream& s, const bool& x) {
+    s << std::boolalpha << x << std::noboolalpha;
+}
+
+template <>
+inline void ostream_insertion<double>(std::ostream& s, const double& x) {
+    using namespace double_conversion;
+
+    const DoubleToStringConverter& c(DoubleToStringConverter::EcmaScriptConverter());
+    char buf[32] = { 0 };
+    StringBuilder builder(buf, sizeof(buf));
+    c.ToShortest(x, &builder);
+
+    s << builder.Finalize();
+}
+
+/*************************************************************************************************/
+// serialize<T> is an opportunity to hook user-defined wrapper types (e.g., boost::reference_wrapper)
+
+template <typename T>
+struct serialize {
+    void operator()(std::ostream& s, const T& x) const {
+        ostream_insertion(s, x);
+    }
+};
+
+template <typename T>
+struct serialize<std::reference_wrapper<T>> {
+    void operator()(std::ostream& s, const std::reference_wrapper<T>& x) const {
+        ostream_insertion(s, x.get());
+    }
+};
+
+/*************************************************************************************************/
+
+class serializable_t {
+public:    
+    template <typename T>
+    explicit serializable_t(T x) :
+        instance_m(new instance<T>(x)) {}
+
+    serializable_t(const serializable_t& x) :
+        instance_m(x.object()._copy()) {}
+
+    serializable_t(serializable_t&& x) :
+        instance_m(x.instance_m.release()) {}
+
+    void operator()(std::ostream& s) const {
+        object()(s);
+    }
+
+    const std::type_info& type_info() const {
+        return object().type_info();
+    }
+
+    template <typename T>
+    const T& cast() const {
+        const std::type_info& type(type_info());
+
+        if (type != typeid(T))
+            throw bad_cast(type, typeid(T));
+
+        return static_cast<const T&>(reinterpret_cast<const instance<T>&>(object()).object_m);
+    }
+
+    template <typename T>
+    T& cast() {
+        return const_cast<T&>(const_cast<const serializable_t&>(*this).cast<T>());
+    }
+
+private:
+    struct instance_t {
+        virtual ~instance_t() {}
+
+        virtual instance_t* _copy() const = 0;
+
+        virtual void operator()(std::ostream& s) const = 0;
+        virtual const std::type_info& type_info() const = 0;
+    };
+
+    template <typename T>
+    struct instance : instance_t {
+        explicit instance(T x) :
+            object_m(std::move(x)) {}
+
+        instance_t* _copy() const {
+            return new instance(object_m);
+        }
+
+        void operator()(std::ostream& s) const {
+            serialize<T>()(s, object_m);
+        }
+
+        const std::type_info& type_info() const {
+            return typeid (T);
+        }
+
+        T object_m;
+    };
+
+    instance_t& object() { return *instance_m; }
+    const instance_t& object() const { return *instance_m; }
+
+    std::unique_ptr<instance_t> instance_m;
+};
+
+/*************************************************************************************************/
+
+inline std::ostream& operator<<(std::ostream& s, const serializable_t& x) {
+    x(s);
+
+    return s;
+}
+
+/*************************************************************************************************/
+
+} // namespace adobe
+
+/*************************************************************************************************/
+
+#endif
+
+/*************************************************************************************************/

--- a/source/any_regular.cpp
+++ b/source/any_regular.cpp
@@ -43,92 +43,7 @@ namespace adobe {
 
 /**************************************************************************************************/
 
-namespace implementation {
-
-/**************************************************************************************************/
-
-struct serializable_t {
-    virtual ~serializable_t() {};
-    virtual void operator()(std::ostream& out, const any_regular_t& x) const = 0;
-};
-
-/**************************************************************************************************/
-
-template <typename T>
-struct serializable : serializable_t {
-    serializable() {}
-    void operator()(std::ostream& out, const any_regular_t& x) const { out << format(x.cast<T>()); }
-};
-
-/**************************************************************************************************/
-
-template <>
-struct serializable<double> : serializable_t {
-    serializable() {}
-    void operator()(std::ostream& out, const any_regular_t& x) const {
-        using namespace double_conversion;
-
-        const DoubleToStringConverter& c(DoubleToStringConverter::EcmaScriptConverter());
-        char                           buf[32] = { 0 };
-        StringBuilder                  builder(buf, sizeof(buf));
-        c.ToShortest(x.cast<double>(), &builder);
-        out << builder.Finalize();
-    }
-};
-
-/**************************************************************************************************/
-
-template <typename T, typename Any = void>
-struct make_serializable {
-    static const serializable<T> value;
-};
-
-template <typename T, typename Any>
-const serializable<T> make_serializable<T, Any>::value;
-
-/**************************************************************************************************/
-
-typedef aggregate_pair<const std::type_info*, const serializable_t*> serializable_lookup_t;
-
-serializable_lookup_t serializable_table[] = {
-    {&typeid(bool), &make_serializable<bool>::value},
-    {&typeid(dictionary_t), &make_serializable<dictionary_t>::value},
-    {&typeid(double), &make_serializable<double>::value},
-    {&typeid(empty_t), &make_serializable<empty_t>::value},
-    {&typeid(name_t), &make_serializable<name_t>::value},
-    {&typeid(string), &make_serializable<string>::value},
-    {&typeid(array_t), &make_serializable<array_t>::value}};
-
-/**************************************************************************************************/
-
-} // namespace implementation
-
-/**************************************************************************************************/
-
 namespace version_1 {
-
-std::ostream& operator<<(std::ostream& out, const any_regular_t& x) {
-    using namespace implementation;
-
-    static bool inited = false;
-
-    if (!inited) {
-        inited = true;
-        sort(serializable_table, &std::type_info::before,
-             [](const serializable_lookup_t & x)->const std::type_info & { return *x.first; });
-    }
-
-    serializable_lookup_t* i = binary_search(
-        serializable_table, x.type_info(), &std::type_info::before,
-        [](const serializable_lookup_t & x)->const std::type_info & { return *x.first; });
-
-    if (i == boost::end(serializable_table))
-        throw std::logic_error("Type not serializable.");
-
-    (*i->second)(out, x);
-
-    return out;
-}
 
 std::ostream& operator<<(std::ostream& out, const dictionary_t& x) {
     typedef table_index<const name_t, const dictionary_t::value_type> index_type;
@@ -142,7 +57,7 @@ std::ostream& operator<<(std::ostream& out, const dictionary_t& x) {
          ++first) {
         out << begin_sequence;
         out << format(first->first);
-        out << format(first->second);
+        out << first->second; // format will be called by any_regular_t.
         out << end_sequence;
     }
 

--- a/source/iomanip_asl_cel.cpp
+++ b/source/iomanip_asl_cel.cpp
@@ -45,7 +45,7 @@ void asl_cel_format::begin_sequence(stream_type& os) {
 
 /*************************************************************************************************/
 
-void asl_cel_format::begin_atom(stream_type& os, const any_regular_t& value) {
+void asl_cel_format::begin_atom(stream_type& os, const serializable_t& value) {
     push_stack(os, format_element_t(atom_name_g, value));
 }
 
@@ -91,7 +91,7 @@ void asl_cel_format::handle_atom(stream_type& os, bool is_push) {
     const format_element_t& top(stack_top());
     name_t                  parent(stack_depth() >= 2 ? stack_n(1).tag() : name_t());
     name_t                  grandparent(stack_depth() >= 3 ? stack_n(2).tag() : name_t());
-    const any_regular_t&    value(top.value());
+    const serializable_t&   value(top.value());
     bool                    outputting_bag(parent == seq_name_g && grandparent == bag_name_g);
     std::size_t&            num_out(outputting_bag ? stack_n(2).num_out_m : stack_n(1).num_out_m);
     bool                    named_argument(outputting_bag && (num_out & 0x1) == 0);

--- a/source/iomanip_javascript.cpp
+++ b/source/iomanip_javascript.cpp
@@ -58,7 +58,7 @@ void javascript_format::begin_sequence(stream_type& os) {
 
 /*************************************************************************************************/
 
-void javascript_format::begin_atom(stream_type& os, const any_regular_t& value) {
+void javascript_format::begin_atom(stream_type& os, const serializable_t& value) {
     push_stack(os, format_element_t(atom_name_g, value));
 }
 
@@ -106,7 +106,7 @@ void javascript_format::handle_atom(stream_type& os, bool is_push) {
     const format_element_t& top(stack_top());
     name_t parent(stack_depth() >= 2 ? stack_n(1).tag() : name_t());
     name_t grandparent(stack_depth() >= 3 ? stack_n(2).tag() : name_t());
-    const any_regular_t& value(top.value());
+    const serializable_t& value(top.value());
     bool outputting_bag(parent == seq_name_g && grandparent == bag_name_g);
     std::size_t& num_out(outputting_bag ? stack_n(2).num_out_m : stack_n(1).num_out_m);
     bool named_argument(outputting_bag && num_out % 2 == 0);

--- a/source/iomanip_pdf.cpp
+++ b/source/iomanip_pdf.cpp
@@ -56,7 +56,7 @@ void pdf_format::begin_sequence(stream_type& os) { push_stack(os, format_element
 
 /*************************************************************************************************/
 
-void pdf_format::begin_atom(stream_type& os, const any_regular_t& value) {
+void pdf_format::begin_atom(stream_type& os, const serializable_t& value) {
     push_stack(os, format_element_t(atom_name_g, value));
 }
 
@@ -106,7 +106,7 @@ void pdf_format::handle_atom(stream_type& os, bool is_push) {
     const format_element_t& top(stack_top());
     name_t parent(stack_depth() >= 2 ? stack_n(1).tag() : name_t());
     name_t grandparent(stack_depth() >= 3 ? stack_n(2).tag() : name_t());
-    const any_regular_t& value(top.value());
+    const serializable_t& value(top.value());
     bool outputting_bag(parent == seq_name_g && grandparent == bag_name_g);
     std::size_t& num_out(outputting_bag ? stack_n(2).num_out_m : stack_n(1).num_out_m);
     bool named_argument(outputting_bag && num_out % 2 == 0);

--- a/source/iomanip_xml.cpp
+++ b/source/iomanip_xml.cpp
@@ -57,7 +57,7 @@ void xml_format::begin_sequence(stream_type& os) { push_stack(os, format_element
 
 /*************************************************************************************************/
 
-void xml_format::begin_atom(stream_type& os, const any_regular_t& value) {
+void xml_format::begin_atom(stream_type& os, const serializable_t& value) {
     push_stack(os, format_element_t(atom_name_g, value));
 }
 
@@ -110,7 +110,7 @@ void xml_format::handle_atom(stream_type& os, bool is_push) {
     name_t self(top.tag());
     name_t parent(stack_depth() >= 2 ? stack_n(1).tag() : name_t());
     name_t grandparent(stack_depth() >= 3 ? stack_n(2).tag() : name_t());
-    const any_regular_t& value(top.value());
+    const serializable_t& value(top.value());
 
     if (is_push) {
         if (self != seq_name_g)

--- a/test/jamfile.jam
+++ b/test/jamfile.jam
@@ -29,3 +29,5 @@ build-project to_string ;
 build-project unicode ;
 build-project xml_parser ;
 build-project zuidgen ;
+
+build-project unit_tests ;

--- a/test/property_model_eval/iomanip_flat.cpp
+++ b/test/property_model_eval/iomanip_flat.cpp
@@ -41,7 +41,7 @@ void flat_format::begin_sequence(stream_type& os) { push_stack(os, format_elemen
 
 /*************************************************************************************************/
 
-void flat_format::begin_atom(stream_type& os, const any_regular_t& value) {
+void flat_format::begin_atom(stream_type& os, const serializable_t& value) {
     push_stack(os, format_element_t(atom_name_g, value));
 }
 
@@ -87,7 +87,7 @@ void flat_format::handle_atom(stream_type& os, bool is_push) {
     const format_element_t& top(stack_top());
     name_t parent(stack_depth() >= 2 ? stack_n(1).tag() : name_t());
     name_t grandparent(stack_depth() >= 3 ? stack_n(2).tag() : name_t());
-    const any_regular_t& value(top.value());
+    const serializable_t& value(top.value());
     bool outputting_bag(parent == seq_name_g && grandparent == bag_name_g);
     std::size_t& num_out(outputting_bag ? stack_n(2).num_out_m : stack_n(1).num_out_m);
     bool named_argument(outputting_bag && (num_out & 0x1) == 0);

--- a/test/property_model_eval/iomanip_flat.hpp
+++ b/test/property_model_eval/iomanip_flat.hpp
@@ -40,7 +40,7 @@ public:
 
     virtual void begin_sequence(stream_type& os);
 
-    virtual void begin_atom(stream_type& os, const any_regular_t&);
+    virtual void begin_atom(stream_type& os, const serializable_t&);
 
 private:
     virtual void stack_event(stream_type& os, bool is_push);

--- a/test/unit_tests/any_regular/any_regular_serialization_test.cpp
+++ b/test/unit_tests/any_regular/any_regular_serialization_test.cpp
@@ -1,0 +1,48 @@
+/*
+    Copyright 2013 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+/*************************************************************************************************/
+
+#include <adobe/config.hpp>
+
+#include <functional>
+#include <utility>
+
+#include <boost/test/unit_test.hpp>
+
+#include <adobe/any_regular.hpp>
+
+/*************************************************************************************************/
+
+struct foo_t { int x; };
+bool operator==(const foo_t& x, const foo_t& y) { return x.x == y.x; };
+bool operator!=(const foo_t& x, const foo_t& y) { return !(x == y); }
+
+// foo_t has operator<< defined. As such the following routine will be called
+// when foo_t is wrapped in an any_regular_t.
+void operator<<(std::ostream& s, const foo_t& x) {
+    s << x.x;
+}
+
+// bar_t has no operator<< defined. As such it will not be serialized when bar_t
+// is wrapped in an any_regular_t.
+struct bar_t { };
+bool operator==(const bar_t& x, const bar_t& y) { return true; };
+bool operator!=(const bar_t& x, const bar_t& y) { return !(x == y); }
+
+void any_regular_serialization_test() {
+    using adobe::any_regular_t;
+
+    std::cout << "foo_t: " << any_regular_t(foo_t{42}) << '\n';
+    std::cout << "bar_t: " << any_regular_t(bar_t()) << '\n';
+}
+
+using namespace boost::unit_test;
+
+test_suite* init_unit_test_suite(int, char * []) {
+    framework::master_test_suite().add(BOOST_TEST_CASE(&any_regular_serialization_test));
+
+    return 0;
+}

--- a/test/unit_tests/any_regular/jamfile.jam
+++ b/test/unit_tests/any_regular/jamfile.jam
@@ -1,1 +1,2 @@
 run any_regular_test.cpp ;
+run any_regular_serialization_test.cpp ;

--- a/test/unit_tests/jamfile.jam
+++ b/test/unit_tests/jamfile.jam
@@ -7,3 +7,4 @@ build-project erase ;
 build-project forest ;
 build-project lower_bound ;
 build-project name ;
+build-project serializable ;

--- a/test/unit_tests/serializable/jamfile.jam
+++ b/test/unit_tests/serializable/jamfile.jam
@@ -1,0 +1,1 @@
+run serializable.cpp ;

--- a/test/unit_tests/serializable/serializable.cpp
+++ b/test/unit_tests/serializable/serializable.cpp
@@ -1,0 +1,59 @@
+/*
+    Copyright 2013 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+/**************************************************************************************************/
+
+#include <cmath>
+
+#include <boost/test/unit_test.hpp>
+
+#include <adobe/array.hpp>
+#include <adobe/dictionary.hpp>
+#include <adobe/empty.hpp>
+#include <adobe/name.hpp>
+#include <adobe/serializable.hpp>
+
+/**************************************************************************************************/
+
+void serializable_test() {
+    using namespace adobe;
+    using namespace adobe::literals;
+
+    std::cout << serializable_t(42) << '\n';
+    std::cout << serializable_t(bool()) << '\n';
+    std::cout << serializable_t(true) << '\n';
+    std::cout << serializable_t(dictionary_t()) << '\n';
+    std::cout << serializable_t(M_PI) << '\n';
+    std::cout << serializable_t(empty_t()) << '\n';
+    std::cout << serializable_t(name_t()) << '\n';
+    std::cout << serializable_t(name_t("name_t")) << '\n';
+    std::cout << serializable_t("const char*") << '\n';
+    std::cout << serializable_t(std::string("std::string")) << '\n';
+    std::cout << serializable_t(array_t()) << '\n';
+
+    dictionary_t dict;
+
+    dict["key"_name].assign("value");
+
+    std::cout << serializable_t(std::cref(dict)) << '\n';
+
+    array_t array;
+
+    push_back(array, "value");
+
+    std::cout << serializable_t(std::cref(array)) << '\n';
+}
+
+/**************************************************************************************************/
+
+using namespace boost::unit_test;
+
+test_suite* init_unit_test_suite(int, char * []) {
+    framework::master_test_suite().add(BOOST_TEST_CASE(&serializable_test));
+
+    return 0;
+}
+
+/**************************************************************************************************/


### PR DESCRIPTION
When it is not defined, the result is (eventually) a no-op.

Added a serializable_t concept type, and propagated it through the iomanip code, so an iomanip-able type now need only be serializable, not regular.

Added a new any_regular serialization test, and asserted that test/serialization still outputs as expected.