### PR TITLE
cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_definitions ("-Werror")
 # For double-conversion, the unix makefile setup is able to download the git
 # repo and build it
 
-option(USE_SYSTEM_boost "use cmake found boost instead of ../boost_libraries" "ON")
+option(USE_SYSTEM_BOOST "use cmake found boost instead of ../boost_libraries" "ON")
 option(USE_STLAB_DOUBLECONV "use stlab mirror of double-conversion repository" "OFF")
 
 set(root_path ${CMAKE_SOURCE_DIR}/../)
@@ -52,7 +52,7 @@ endif()
 
 function(target_link_boost target)
     if (${USE_SYSTEM_BOOST})
-        target_link_libraries(${target} PUBLIC ${Boost_SYSTEM_LIBRARY})
+        target_link_libraries(${target} PUBLIC ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_THREAD_LIBRARY})
     else()
         add_dependencies(${target} boost_glob)
 
@@ -72,7 +72,7 @@ function(target_link_boost_test target)
 endfunction(target_link_boost_test)
 
 if (${USE_SYSTEM_BOOST})
-    find_package(Boost COMPONENTS system thread unit_test_framework program_options REQUIRED)
+    find_package(Boost COMPONENTS system filesystem thread unit_test_framework program_options REQUIRED)
 else()
     message("ASL_INFO: Building boost ourselves.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-include(ExternalProject)
+include(FindGit)
 include(CMakeParseArguments)
 enable_testing()
 
@@ -21,50 +21,34 @@ add_definitions ("-Werror")
 # and are ready for use by CMake. Otherwise, we'll have to roll them ourselves.
 #
 # For double-conversion, the unix makefile setup is able to download the git
-# repo and build it. For Xcode, this isn't the case, and we'll have to roll
-# our own there, too.
+# repo and build it
 
-option(USE_SYSTEM_BOOST "use cmake found boost instead of ../boost_libraries" "OFF")
+option(USE_SYSTEM_boost "use cmake found boost instead of ../boost_libraries" "ON")
+option(USE_STLAB_DOUBLECONV "use stlab mirror of double-conversion repository" "OFF")
 
-if (${CMAKE_GENERATOR} STREQUAL "Xcode")
-    set(ASL_DOUBLECONV_SUPPORT ON)
+set(root_path ${CMAKE_SOURCE_DIR}/../)
 
-    message("ASL_INFO: Building double-conversion ourselves.")
-else()
-    set(ASL_DOUBLECONV_SUPPORT OFF)
-endif()
-
-if (${ASL_DOUBLECONV_SUPPORT})
-    file(GLOB ASL_DOUBELCONV_SRC ../double-conversion/src/*.cc)
-
-    add_library(doubleconv_support STATIC ${ASL_DOUBELCONV_SRC})
-
-    get_filename_component(ASL_DOUBLECONV_PATH ../ ABSOLUTE)
-
-    target_include_directories(doubleconv_support PUBLIC ${ASL_DOUBLECONV_PATH})
-else()
-    ExternalProject_Add(double-conversion_prj
-        PREFIX ${CMAKE_BINARY_DIR}/thirdparty/double-conversion
-        GIT_REPOSITORY https://github.com/google/double-conversion.git
-        # GIT_REPOSITORY https://github.com/stlab/double-conversion.git
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
-
-    link_directories(${CMAKE_INSTALL_PREFIX}/lib)
-endif()
-
-function(target_link_doubleconversion target)
-    if (${ASL_DOUBLECONV_SUPPORT})
-        add_dependencies(${target} doubleconv_support)
-
-        target_link_libraries(${target} PUBLIC doubleconv_support)
-    else()
-        #tweak on include double-conversion path
-        target_compile_definitions(${target} PUBLIC -DADOBE_BUILT_WITH_CMAKE)
-        add_dependencies(${target} double-conversion_prj)
-        target_include_directories(${target} PUBLIC ${CMAKE_INSTALL_PREFIX}/include)
-        target_link_libraries(${target} PUBLIC double-conversion)
+function(setup_dep)
+    set(oneValueArgs URL BRANCH)
+    cmake_parse_arguments(setup_dep "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    get_filename_component(name ${setup_dep_URL} NAME_WE)
+    set(dep_path ${root_path}/${name})
+    if(NOT IS_DIRECTORY ${dep_path})
+        execute_process(COMMAND ${GIT_EXECUTABLE} clone ${setup_dep_URL} WORKING_DIRECTORY ${root_path})
+        execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${setup_dep_BRANCH} WORKING_DIRECTORY ${dep_path})
     endif()
-endfunction(target_link_doubleconversion)
+    add_subdirectory(${dep_path} ${CMAKE_BINARY_DIR}/imported/${name})
+endfunction()
+
+if (${USE_STLAB_DOUBLECONV})
+  setup_dep(URL https://github.com/stlab/double-conversion.git BRANCH master)
+  target_include_directories(double-conversion PUBLIC $<BUILD_INTERFACE:${root_path}>)
+else()
+  setup_dep(URL https://github.com/google/double-conversion.git BRANCH master)
+  target_include_directories(double-conversion PUBLIC $<BUILD_INTERFACE:${root_path}/double-conversion>)
+  # poorly named flag to fix include path
+  target_compile_definitions(double-conversion PUBLIC ADOBE_BUILT_WITH_CMAKE)
+endif()
 
 function(target_link_boost target)
     if (${USE_SYSTEM_BOOST})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,16 +10,21 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++0x")
 set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 
+add_definitions ("-Wall")
+add_definitions ("-Werror")
+
 # There are two big choices this file makes - how to include Boost, and how to
 # include double-conversion, respectively. Build environments vary and we're
 # trying to support all of them.
 #
-# If BOOST_ROOT is defined, that means the headers and libraries have been built
+# If USE_SYSTEM_BOOST is defined, that means the headers and libraries have been built
 # and are ready for use by CMake. Otherwise, we'll have to roll them ourselves.
 #
 # For double-conversion, the unix makefile setup is able to download the git
 # repo and build it. For Xcode, this isn't the case, and we'll have to roll
 # our own there, too.
+
+option(USE_SYSTEM_BOOST "use cmake found boost instead of ../boost_libraries" "OFF")
 
 if (${CMAKE_GENERATOR} STREQUAL "Xcode")
     set(ASL_DOUBLECONV_SUPPORT ON)
@@ -62,7 +67,7 @@ function(target_link_doubleconversion target)
 endfunction(target_link_doubleconversion)
 
 function(target_link_boost target)
-    if (${BOOST_ROOT})
+    if (${USE_SYSTEM_BOOST})
         target_link_libraries(${target} PUBLIC ${Boost_SYSTEM_LIBRARY})
     else()
         add_dependencies(${target} boost_glob)
@@ -72,9 +77,9 @@ function(target_link_boost target)
 endfunction(target_link_boost)
 
 function(target_link_boost_test target)
-    if (${BOOST_ROOT})
-        target_compile_definitions(${asl_test_NAME} PRIVATE BOOST_TEST_DYN_LINK)
-        target_link_libraries(${asl_test_NAME} PRIVATE ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    if (${USE_SYSTEM_BOOST})
+        target_compile_definitions(${target} PRIVATE BOOST_TEST_DYN_LINK)
+        target_link_libraries(${target} PRIVATE ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
     else()
         add_dependencies(${target} boost_unit_test)
 
@@ -82,7 +87,7 @@ function(target_link_boost_test target)
     endif()
 endfunction(target_link_boost_test)
 
-if (${BOOST_ROOT})
+if (${USE_SYSTEM_BOOST})
     find_package(Boost COMPONENTS system thread unit_test_framework program_options REQUIRED)
 else()
     message("ASL_INFO: Building boost ourselves.")

--- a/adobe/serializable.hpp
+++ b/adobe/serializable.hpp
@@ -12,8 +12,13 @@
 
 #include <type_traits>
 #include <ostream>
+#include <memory>
 
+#ifdef ADOBE_BUILT_WITH_CMAKE
+#include <double-conversion/double-conversion.h>
+#else
 #include <double-conversion/src/double-conversion.h>
+#endif
 
 #include <adobe/typeinfo.hpp>
 

--- a/adobe/string/to_string.hpp
+++ b/adobe/string/to_string.hpp
@@ -113,7 +113,7 @@ O to_string(double x, O out, bool precise = false) {
     int size = _snprintf_s(&buf[0], sizeof(buf), sizeof(buf), "%.*g", precise ? 17 : 15, x);
 #else
     int size = std::snprintf(&buf[0], sizeof(buf), "%.*g", precise ? 17 : 15, x);
-    ADOBE_ASSERT(size < sizeof(buf) && "WARNING (sparent) : snprintf truncated.");
+    ADOBE_ASSERT(size < static_cast<int>(sizeof(buf)) && "WARNING (sparent) : snprintf truncated.");
 #endif
     ADOBE_ASSERT(size < (precise ? 25 : 23) &&
                  "WARNING (sparent) : to_string() result larger than expected.");

--- a/cmake_build.sh
+++ b/cmake_build.sh
@@ -7,16 +7,18 @@ BUILDMODE=${BUILDMODE:-RELEASE}
 if [ "$TOOLSET" == "xcode" ]; then
     mkdir -p ../${BUILDDIR}/xcode/${BUILDMODE}
     pushd ../${BUILDDIR}/xcode/${BUILDMODE}
-    cmake -DCMAKE_CXX_COMPILER=${TOOLSET} -DCMAKE_BUILD_TYPE=${BUILDMODE} -DCMAKE_INSTALL_PREFIX=stage -G "Xcode" ../../../adobe_source_libraries
+    cmake -DUSE_SYSTEM_BOOST=${SYSTEM_BOOST:-OFF} -DCMAKE_CXX_COMPILER=${TOOLSET} -DCMAKE_BUILD_TYPE=${BUILDMODE} -DCMAKE_INSTALL_PREFIX=stage -G "Xcode" ../../../adobe_source_libraries
     #make -j4
-    #make test
     popd
 else
     mkdir -p ../${BUILDDIR}/${TOOLSET}/${BUILDMODE}
     pushd ../${BUILDDIR}/${TOOLSET}/${BUILDMODE}
-    cmake -DCMAKE_CXX_COMPILER=${TOOLSET} -DCMAKE_BUILD_TYPE=${BUILDMODE} -DCMAKE_INSTALL_PREFIX=stage -G "Unix Makefiles" ../../../adobe_source_libraries
+    cmake -DUSE_SYSTEM_BOOST=${SYSTEM_BOOST:-ON} -DCMAKE_CXX_COMPILER=${TOOLSET} -DCMAKE_BUILD_TYPE=${BUILDMODE} -DCMAKE_INSTALL_PREFIX=stage -G "Unix Makefiles" ../../../adobe_source_libraries
     make -j4
-    make test
+    # "ctest -C ${BUILDMODE}" handles CONFIGURATIONS option of CMake's add_test
+    # "make test" only run tests declared without any CONFIGURATIONS flag
+    ctest -C ${BUILDMODE}
     popd
 fi
+
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -17,6 +17,6 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR
     target_compile_options(asl PUBLIC -ftemplate-depth=1024)
 endif()
 
-target_link_doubleconversion(asl)
+target_link_libraries(asl PUBLIC double-conversion)
 
 target_link_boost(asl)

--- a/source/adam.cpp
+++ b/source/adam.cpp
@@ -287,8 +287,8 @@ private:
         cell_t* interface_input_m;
 
         priority_t priority() const {
-            assert(specifier_m == access_interface_input ||
-                   specifier_m == access_interface_output &&
+            assert((specifier_m == access_interface_input ||
+                   specifier_m == access_interface_output) &&
                        "should not read priority of this cell type");
             return interface_input_m ? interface_input_m->priority_m : priority_m;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,23 @@
 function(asl_test)
-  set(options SKIPPED BOOST)
+  set(options SKIPPED BOOST BENCHMARK)
   set(oneValueArgs NAME)
   set(multiValueArgs SOURCES ARGS)
   cmake_parse_arguments(asl_test "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   add_executable (${asl_test_NAME} ${asl_test_SOURCES})
+
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-deprecated")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-unused-variable")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-unknown-pragmas")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-uninitialized")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-return-type")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-unused-function")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-unused-local-typedefs")
+  target_compile_options (${asl_test_NAME} PRIVATE "-Wno-unused-parameter")
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options (${asl_test_NAME} PRIVATE "-Wno-unused-comparison")
+  endif()
+
   target_link_libraries(${asl_test_NAME} PRIVATE asl)
 
   if (asl_test_BOOST)
@@ -12,7 +25,11 @@ function(asl_test)
   endif(asl_test_BOOST)
 
   if (NOT asl_test_SKIPPED)
-    add_test (NAME ${asl_test_NAME} COMMAND ${asl_test_NAME} ${asl_test_ARGS})
+    if (asl_test_BENCHMARK)
+        add_test (NAME ${asl_test_NAME} COMMAND ${asl_test_NAME} ${asl_test_ARGS} CONFIGURATIONS Release)
+    else(asl_test_BENCHMARK)
+        add_test (NAME ${asl_test_NAME} COMMAND ${asl_test_NAME} ${asl_test_ARGS})
+    endif(asl_test_BENCHMARK)
   endif(NOT asl_test_SKIPPED)
 endfunction(asl_test)
 

--- a/test/adam_smoke/CMakeLists.txt
+++ b/test/adam_smoke/CMakeLists.txt
@@ -1,1 +1,5 @@
-asl_test(NAME adam_smoke_test SOURCES adam_smoke_test.cpp ARGS rtd.adm)
+add_executable (adam_smoke_test adam_smoke_test.cpp)
+target_link_libraries(adam_smoke_test PRIVATE asl)
+
+add_test (NAME adam_smoke_test_rtd COMMAND adam_smoke_test ut_mode ${CMAKE_CURRENT_SOURCE_DIR}/rtd.adm)
+add_test (NAME adam_smoke_test_io COMMAND adam_smoke_test ut_mode ${CMAKE_CURRENT_SOURCE_DIR}/io.adm)

--- a/test/dictionary_benchmark/CMakeLists.txt
+++ b/test/dictionary_benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
 # quite long pure perf benchmarck. not sure we want to run it automatically
-asl_test(SKIPPED NAME dictionary_benchmark SOURCES main.cpp)
+asl_test(BENCHMARK NAME dictionary_benchmark SOURCES main.cpp)
 target_link_libraries(dictionary_benchmark PRIVATE ${Boost_THREAD_LIBRARY})
 

--- a/test/sha/CMakeLists.txt
+++ b/test/sha/CMakeLists.txt
@@ -1,3 +1,4 @@
 asl_test (BOOST NAME sha_smoketest SOURCES main.cpp)
 asl_test (BOOST NAME sha_shavs SOURCES shavs.cpp)
-asl_test (NAME sha_benchmark SOURCES bench.cpp)
+asl_test (BENCHMARK NAME sha_benchmark SOURCES bench.cpp)
+

--- a/test/unit_tests/any_regular/CMakeLists.txt
+++ b/test/unit_tests/any_regular/CMakeLists.txt
@@ -1,1 +1,2 @@
 asl_test(BOOST NAME any_regular_test SOURCES any_regular_test.cpp)
+asl_test(BOOST NAME any_regular_serialization_test SOURCES any_regular_serialization_test.cpp)

--- a/test/unit_tests/any_regular/any_regular_serialization_test.cpp
+++ b/test/unit_tests/any_regular/any_regular_serialization_test.cpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <utility>
 
+#define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
 #include <adobe/any_regular.hpp>
@@ -32,17 +33,9 @@ struct bar_t { };
 bool operator==(const bar_t& x, const bar_t& y) { return true; };
 bool operator!=(const bar_t& x, const bar_t& y) { return !(x == y); }
 
-void any_regular_serialization_test() {
+BOOST_AUTO_TEST_CASE(any_regular_serialization_test) {
     using adobe::any_regular_t;
 
     std::cout << "foo_t: " << any_regular_t(foo_t{42}) << '\n';
     std::cout << "bar_t: " << any_regular_t(bar_t()) << '\n';
-}
-
-using namespace boost::unit_test;
-
-test_suite* init_unit_test_suite(int, char * []) {
-    framework::master_test_suite().add(BOOST_TEST_CASE(&any_regular_serialization_test));
-
-    return 0;
 }


### PR DESCRIPTION
On my Fedora, I have no BOOST_ROOT defined and Boost is split into /usr/include and /usr/lib64
So I changed to an explicit flag asking to use find_package (which is supposed to detect BOOST_ROOT, if present)

ctest usage in sh scripts is to run BENCHMARK tests in Release mode only.

The shift_down template is to silence an arguable GCC warning on potential shift overflow.
GCC does not detect that the "constexpr if" prevents that ... With template, offending code is not instantiated.
