### PR TITLE
build fixes after GCC6 and boost 1.60 update

### DIFF
--- a/adobe/any_regular.hpp
+++ b/adobe/any_regular.hpp
@@ -498,7 +498,7 @@ public:
     */
 
     template <typename T>
-    any_regular_t(T x) {
+    explicit any_regular_t(T x) {
         ::new (storage()) typename traits<T>::model_type(std::move(x));
     }
 

--- a/adobe/cmath.hpp
+++ b/adobe/cmath.hpp
@@ -48,7 +48,7 @@ back to include math.h. This also needs to add any other C99 math.h extensions.
 
 #define ADOBE_HAS_C99_STD_MATH_H
 #endif
-#elif __GNUC__ == 5
+#elif __GNUC__ >= 5
 #define ADOBE_HAS_C99_STD_MATH_H
 #include <cmath>
 #endif

--- a/adobe/iomanip.hpp
+++ b/adobe/iomanip.hpp
@@ -29,6 +29,8 @@
 #include <adobe/manip.hpp>
 #include <adobe/name.hpp>
 
+#include <boost/next_prior.hpp>
+
 /*************************************************************************************************/
 
 namespace adobe {

--- a/adobe/name.hpp
+++ b/adobe/name.hpp
@@ -12,10 +12,12 @@
 /**************************************************************************************************/
 
 // stdc++
+#include <cstring>
 #include <functional>
 #include <iosfwd>
 
 // boost
+#include <boost/mpl/bool.hpp>
 #include <boost/operators.hpp>
 #include <boost/type_traits/is_pod.hpp>
 

--- a/adobe/once.hpp
+++ b/adobe/once.hpp
@@ -8,12 +8,6 @@
 #ifndef ADOBE_ONCE_HPP
 #define ADOBE_ONCE_HPP
 
-#include <adobe/config.hpp>
-
-#if defined(BOOST_HAS_THREADS)
-#include <boost/thread.hpp>
-#endif
-
 /**************************************************************************************************/
 
 /*
@@ -29,105 +23,30 @@ to do something here.
 
 /**************************************************************************************************/
 
-#if 0
+#ifdef ADOBE_STD_THREAD_LOCAL
 
-/**************************************************************************************************/
+#define ADOBE_THREAD_LOCAL_STORAGE_1(type, signature, ctor_p1)                                     \
+    type& adobe_thread_local_storage_##signature##_access() {                                      \
+        thread_local type holder {ctor_p1};                                                        \
+        return holder;                                                                             \
+    }                                                                                              \
 
-namespace adobe {
+#define ADOBE_THREAD_LOCAL_STORAGE(type, signature)                                                \
+    type& adobe_thread_local_storage_##signature##_access() {                                      \
+        thread_local type holder;                                                                  \
+        return holder;                                                                             \
+    }                                                                                              \
 
-/**************************************************************************************************/
+#define ADOBE_THREAD_LOCAL_STORAGE_INITIALIZE(signature)                                           \
 
-#if defined(BOOST_HAS_THREADS)
-
-/**************************************************************************************************/
-
-typedef boost::once_flag    once_flag;
-#define ADOBE_ONCE_INIT BOOST_ONCE_INIT
-
-inline void call_once(void (*func)(), adobe::once_flag& flag)
-{
-    boost::call_once(func, flag);
-}
-
-/**************************************************************************************************/
 
 #else
 
-/**************************************************************************************************/
-
-typedef bool                once_flag;
-#define ADOBE_ONCE_INIT false
-
-inline void call_once(void (*func)(), adobe::once_flag& flag)
-{
-    if (!flag)
-    {
-        (*func)();
-        flag = true;
-    }
-}
-
-/**************************************************************************************************/
-
-#endif
-
-/**************************************************************************************************/
-
-} // namespace adobe
-
-/**************************************************************************************************/
-
-#define ADOBE_ONCE_DECLARATION(signature)                                                          \
-    struct adobe_initialize_constants_##signature##_t {                                            \
-        adobe_initialize_constants_##signature##_t();                                              \
-    };
-
-#define ADOBE_ONCE_DEFINITION(signature, func)                                                     \
-    namespace {                                                                                    \
-    adobe::once_flag adobe_once_flag_##signature##_s = ADOBE_ONCE_INIT;                            \
-    }                                                                                              \
-    adobe_initialize_constants_##signature##_t::adobe_initialize_constants_##signature##_t() {     \
-        adobe::call_once(&func, adobe_once_flag_##signature##_s);                                  \
-    }
-
-#define ADOBE_ONCE_INSTANCE(signature)                                                             \
-    adobe_initialize_constants_##signature##_t adobe_initialize_constants_##signature##_s
-
-#define ADOBE_ONCE_STATIC_INSTANCE(signature)                                                      \
-    namespace {                                                                                    \
-    ADOBE_ONCE_INSTANCE(signature);                                                                \
-    }
+#include <adobe/config.hpp>
 
 #if defined(BOOST_HAS_THREADS)
 
-#define ADOBE_GLOBAL_MUTEX_DEFINITION(signature)                                                   \
-    namespace {                                                                                    \
-    adobe::once_flag adobe_once_flag_##signature##_s = ADOBE_ONCE_INIT;                            \
-    boost::mutex* adobe_mutex_ptr_##signature##_s = 0;                                             \
-    void adobe_init_once_##signature() {                                                           \
-        static boost::mutex mutex_s;                                                               \
-        adobe_mutex_ptr_##signature##_s = &mutex_s;                                                \
-    }                                                                                              \
-    }
-
-#define ADOBE_GLOBAL_MUTEX_INSTANCE(signature)                                                     \
-    boost::call_once(&adobe_init_once_##signature, adobe_once_flag_##signature##_s);               \
-    boost::mutex::scoped_lock lock(*adobe_mutex_ptr_##signature##_s)
-
-#else
-
-#define ADOBE_GLOBAL_MUTEX_DEFINITION(signature)
-#define ADOBE_GLOBAL_MUTEX_INSTANCE(signature)
-
-#endif
-
-/**************************************************************************************************/
-
-#endif // #if 0
-
-/**************************************************************************************************/
-
-#if defined(BOOST_HAS_THREADS)
+#include <boost/thread.hpp>
 
 #define ADOBE_THREAD_LOCAL_STORAGE_1(type, signature, ctor_p1)                                     \
     namespace {                                                                                    \
@@ -180,6 +99,8 @@ inline void call_once(void (*func)(), adobe::once_flag& flag)
     }
 
 #define ADOBE_THREAD_LOCAL_STORAGE_INITIALIZE(signature)
+
+#endif
 
 #endif
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -5,11 +5,26 @@ add_library(asl ${SRC_LIST} ${INC_LIST})
 target_include_directories(asl PUBLIC ..)
 target_compile_definitions(asl PUBLIC ADOBE_STD_SERIALIZATION)
 
-#otherwise boost concept checking fails on adobe::selection_t because it lacks non const begin/end
+# otherwise boost concept checking fails on adobe::selection_t because it lacks non const begin/end
 target_compile_definitions(asl PUBLIC -DBOOST_RANGE_ENABLE_CONCEPT_ASSERT=0)
 
-#otherwise boost::move and std::move are ambiguous
-target_compile_definitions(asl PUBLIC -DBOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+# otherwise boost::move and std::move are ambiguous
+# commented out here because ADOBE_STD_ flags below make it irrelevant
+#target_compile_definitions(asl PUBLIC BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+# with boost 1.60 boost.thread uses boost.move unique_ptr
+# which is broken with BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE flag...
+# fix is to conditionally remove boost thread dependency
+# NB: AppleClang lacks thread_local
+if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+    target_compile_definitions(asl PUBLIC ADOBE_STD_THREAD_LOCAL)
+endif()
+
+# GCC6 warning on boost 1.60
+# right operand of shift expression '(1u << 63u)' is >= than the precision of the left operand [-fpermissive]
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    target_compile_definitions(asl PUBLIC ADOBE_FNV_NO_BIGINTS)
+endif()
 
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR
     ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")


### PR DESCRIPTION
About the explicit on any_regular : 
boost::signals2 copies std::tuple internally to store arguments.
eg: a `boost::signals2<void(const any_regular&)>`, easily found in ASL, makes copies of `std::tuple<const any_regular&>`.

With GCC6 and its libstdc++, this fails to compile : 

```
    adobe::any_regular_t val = 12.0;
    std::tuple<const any_regular_t&> tuple_test {val};
    std::tuple<const any_regular_t&> tuple_test_copy {tuple_test};
```
Trap is that last line is not a copy construction. 
It's a tuple construction from elements, with implicit conversion to any_regular.
Here : https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/tuple#L621
So you try to instantiate a any_regular from a non regular type, and get compile error, because "tuple to ref" is not assignable.

PS:
Things are even worse with boost::any for which this code compiles : 

```
    boost::any val = 12.0;
    std::tuple<boost::any> tuple_test {val};
    std::cout << std::get<0>(tuple_test).type().name() << std::endl;

    std::tuple<boost::any> tuple_test_copy {tuple_test};
    std::cout << std::get<0>(tuple_test_copy).type().name() << std::endl;
```

And prints 

> d
> St5tupleIJN5boost3anyEEE
> 

