### PR TITLE
Complete rewrite

### DIFF
--- a/adobe/copy_on_write.hpp
+++ b/adobe/copy_on_write.hpp
@@ -123,13 +123,10 @@ public:
     auto operator=(const copy_on_write& x) noexcept -> copy_on_write& {
         return *this = copy_on_write(x);
     }
+    
     auto operator=(copy_on_write&& x) noexcept -> copy_on_write& {
-        assert(x._self && "WARNING (sparent) : using a moved copy_on_write object");
-        assert((&x != this) && "FATAL (sparent) : invalid self-move.");
-
-        destroy();
-        _self = x._self;
-        x._self = nullptr;
+        auto tmp = std::move(x);
+        swap(*this, tmp);
         return *this;
     }
 

--- a/adobe/copy_on_write.hpp
+++ b/adobe/copy_on_write.hpp
@@ -10,35 +10,16 @@
 
 /**************************************************************************************************/
 
-#include <adobe/config.hpp>
-
-#include <algorithm>
+#include <atomic>
 #include <cassert>
-#include <cstdlib>
-#include <mutex>
-
-#include <boost/noncopyable.hpp>
-#include <boost/operators.hpp>
-#include <boost/static_assert.hpp>
-
-#include <adobe/counter.hpp>
-#include <adobe/memory.hpp>
-#include <adobe/typeinfo.hpp>
+#include <cstddef>
+#include <utility>
 
 /**************************************************************************************************/
 
 namespace adobe {
 
 /**************************************************************************************************/
-
-namespace version_1 {
-
-/**************************************************************************************************/
-
-/*!
-\defgroup abi_misc ABI-Safe Utilities
-\ingroup abi_safe
-*/
 
 /*!
 \ingroup abi_misc util_misc
@@ -55,51 +36,54 @@ copy when the value is modified and there is more than one reference to the
 value.
 
 \note
-copy_on_write is thread safe when complier with BOOST_HAS_THREADS defined.
+copy_on_write is thread safe.
 
-\note
-To get an instance with a particular allocator one would have to write:
-<pre>
-copy_on_write<T> x(custom_allocator);
-x.write() = value;
-</pre>
 */
-template <typename T,                               // T models Regular
-          typename A = adobe::capture_allocator<T>> // A models Allocator
+template <typename T> // T models Regular
 class copy_on_write {
+#if !defined(ADOBE_NO_DOCUMENTATION)
+
+    struct model {
+        std::atomic<std::size_t> _count{1};
+
+        model() = default;
+
+        template <class V>
+        explicit model(V&& x) : _value(std::forward<V>(x)) {}
+
+        T _value;
+    };
+
+    void destroy() {
+        if (_self && (--_self->_count == 0)) delete _self;
+    }
+
+    model* _self;
+
+    template <class U>
+    using disable_copy = std::enable_if_t<!std::is_same<std::decay_t<U>, copy_on_write>::value>*;
+
+    template <typename U>
+    using disable_copy_assign =
+        std::enable_if_t<!std::is_same<std::decay_t<U>, copy_on_write>::value, copy_on_write&>;
+#endif
+
 public:
     /// \brief The type of value stored.
-    typedef T value_type;
-    /// \brief The type of allocator.
-    typedef A allocator_type;
+    /* [[deprecated]] */ using value_type = T;
 
-#if !defined(ADOBE_NO_DOCUMENTATION)
-private:
-    struct implementation_t;
-    typedef typename allocator_type::template rebind<implementation_t>::other
-    implementation_allocator_type;
-
-public:
-#endif
+    /// \brief The type of value stored.
+    using element_type = T;
 
     /*!
         The first call to the default constructor will construct a default
-        instance of value_type which will be used for subsequent calls to the
+        instance of element_type which will be used for subsequent calls to the
         default constructor. The default instance will be released at exit.
     */
     copy_on_write() {
-        std::call_once(flag_s, init_default);
-        object_m = default_s;
-        object_m->header_m.get().count_m.increment();
-    }
-
-    /*!
-        Initializes the instance with a custom allocator
-    */
-    explicit copy_on_write(const allocator_type& a) : object_m(0) {
-        implementation_allocator_type other_allocator(a);
-
-        object_m = allocate(other_allocator);
+        static model default_s;
+        _self = &default_s;
+        ++_self->_count;
     }
 
     /*!
@@ -107,41 +91,43 @@ public:
 
     \param x A default value to assign to this object
     */
-    copy_on_write(T x) : object_m(allocate_move(0, std::move(x))) {}
+    template <class U>
+    copy_on_write(U&& x, disable_copy<U> = nullptr) : _self(new model(std::forward<U>(x))) {}
 
     /*!
     Copy construction is a non-throwing operation and simply increments the
     reference count on the stored object.
     */
-    copy_on_write(const copy_on_write& x) : object_m(x.object_m) {
-        if (object_m)
-            object_m->header_m.get().count_m.increment();
-    }
+    copy_on_write(const copy_on_write& x) noexcept : _self(x._self) { ++_self->_count; }
+    copy_on_write(copy_on_write&& x) noexcept : _self(x._self) { x._self = nullptr; }
 
-    copy_on_write(copy_on_write&& x) : object_m(x.object_m) { x.object_m = 0; }
-
-    ~copy_on_write() { release(object_m); }
+    ~copy_on_write() { destroy(); }
 
     /*!
         As with copy construction, assignment is a non-throwing operation which
         releases the old value and increments the reference count of the item
         being assigned to.
     */
-    copy_on_write& operator=(copy_on_write x) {
-        swap(*this, x);
+    auto operator=(const copy_on_write& x) noexcept -> copy_on_write& {
+        return *this = copy_on_write(x);
+    }
+    auto operator=(copy_on_write&& x) noexcept -> copy_on_write& {
+        assert(!identity(x) && "FATAL (sparent) : invalid self-move.");
+        
+        destroy();
+        _self = x._self;
+        x._self = nullptr;
         return *this;
     }
 
+    template <class U>
+    auto operator=(U&& x) -> disable_copy_assign<U> {
+        if (_self && unique()) {
+            _self->_value = std::forward<U>(x);
+            return *this;
+        }
 
-    copy_on_write& operator=(T x) {
-        if (!object_m)
-            object_m = allocate_move(0, std::move(x));
-        else if (object_m->header_m.get().count_m.is_one())
-            object_m->value_m = std::move(x);
-        else
-            reset(allocate_move(object_m, std::move(x)));
-
-        return *this;
+        return *this = copy_on_write(std::forward<U>(x));
     }
 
     /*!
@@ -156,13 +142,16 @@ public:
 
     \return A reference to the underlying object
     */
-    value_type& write() {
-        assert(object_m && "FATAL (sparent) : using a moved copy_on_write object");
+    auto write() -> element_type& {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
 
-        if (!object_m->header_m.get().count_m.is_one())
-            reset(allocate(object_m, object_m->value_m));
+        if (!unique()) {
+            auto tmp = new model(_self->_value);
+            destroy();
+            _self = tmp;
+        }
 
-        return object_m->value_m;
+        return _self->_value;
     }
 
     /*!
@@ -170,9 +159,10 @@ public:
 
     \return A const reference to the underlying object
     */
-    const value_type& read() const {
-        assert(object_m && "FATAL (sparent) : using a moved copy_on_write object");
-        return object_m->value_m;
+    auto read() const noexcept -> const element_type& {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
+
+        return _self->_value;
     }
 
     /*!
@@ -180,7 +170,7 @@ public:
 
     \return A const reference to the underlying object
     */
-    operator const value_type&() const { return read(); }
+    operator const element_type&() const noexcept { return read(); }
 
     /*!
     \brief Obtain a const reference to the underlying object.
@@ -192,7 +182,7 @@ public:
 
     \return A const reference to the underlying object
     */
-    const value_type& operator*() const { return read(); }
+    auto operator*() const noexcept -> const element_type& { return read(); }
 
     /*!
     \brief Obtain a const pointer to the underlying object.
@@ -204,16 +194,21 @@ public:
 
     \return A const pointer to the underlying object
     */
-    const value_type* operator->() const { return &read(); }
+    auto operator-> () const noexcept -> const element_type* { return &read(); }
 
     /*!
-    \brief unique_instance returns whether or not the reference count to the
+    \brief unique returns whether or not the reference count to the
     object instance is one. This is useful to determine if writing will cause a
     copy.
 
     \return <code>true</code> if the ref count for the instance is one.
     */
-    bool unique_instance() const { return !object_m || object_m->header_m.get().count_m.is_one(); }
+    bool unique() const noexcept {
+        assert(_self && "FATAL (sparent) : using a moved copy_on_write object");
+
+        return _self->_count == 1;
+    }
+    [[deprecated]] bool unique_instance() const noexcept { return unique(); }
 
     /*!
     \brief identity is used to see if two copy_on_write items refer to the same
@@ -222,176 +217,36 @@ public:
     \return Boolean; <code>true</code> if the underlying object instance is
     shared by both objects.
     */
-    bool identity(const copy_on_write& x) const { return object_m == x.object_m; }
+    bool identity(const copy_on_write& x) const noexcept { return _self == x._self; }
 
-    friend inline void swap(copy_on_write& x, copy_on_write& y) {
-        std::swap(x.object_m, y.object_m);
+    friend inline void swap(copy_on_write& x, copy_on_write& y) noexcept {
+        std::swap(x._self, y._self);
     }
 
-    friend inline bool operator<(const copy_on_write& x, const copy_on_write& y) {
-        return y.object_m && (!x.object_m || (!x.identity(y) && *x < *y));
+    friend inline bool operator<(const copy_on_write& x, const copy_on_write& y) noexcept {
+        return !x.identity(y) && (*x < *y);
     }
 
-    friend inline bool operator>(const copy_on_write& x, const copy_on_write& y) { return y < x; }
+    friend inline bool operator>(const copy_on_write& x, const copy_on_write& y) noexcept {
+        return y < x;
+    }
 
-    friend inline bool operator<=(const copy_on_write& x, const copy_on_write& y) {
+    friend inline bool operator<=(const copy_on_write& x, const copy_on_write& y) noexcept {
         return !(y < x);
     }
 
-    friend inline bool operator>=(const copy_on_write& x, const copy_on_write& y) {
+    friend inline bool operator>=(const copy_on_write& x, const copy_on_write& y) noexcept {
         return !(x < y);
     }
 
-    friend inline bool operator==(const copy_on_write& x, const copy_on_write& y) {
-        return x.identity(y) || (x.object_m && y.object_m && *x == *y);
+    friend inline bool operator==(const copy_on_write& x, const copy_on_write& y) noexcept {
+        return x.identity(y) || (*x == *y);
     }
 
-    friend inline bool operator!=(const copy_on_write& x, const copy_on_write& y) {
+    friend inline bool operator!=(const copy_on_write& x, const copy_on_write& y) noexcept {
         return !(x == y);
     }
-
-    allocator_type get_allocator() const {
-        return object_m ? allocator_type(object_m->get_allocator()) : allocator_type();
-    }
-
-private:
-#if !defined(ADOBE_NO_DOCUMENTATION)
-    static implementation_t* allocate(const implementation_t* alloc_src, const T& x = T()) {
-        implementation_allocator_type allocator(alloc_src ? alloc_src->get_allocator()
-                                                          : implementation_allocator_type());
-
-        return allocate(allocator, x);
-    }
-
-    static implementation_t* allocate(implementation_allocator_type& allocator, const T& x = T()) {
-        implementation_t* tmp(allocator.allocate(1));
-
-        try {
-            ::new (static_cast<void*>(tmp)) implementation_t(x);
-        }
-        catch (...) {
-            tmp->get_allocator().deallocate(tmp, 1);
-            throw;
-        }
-
-        return tmp;
-    }
-
-    static implementation_t* allocate_move(const implementation_t* alloc_src, T x) {
-        implementation_allocator_type allocator(alloc_src ? alloc_src->get_allocator()
-                                                          : implementation_allocator_type());
-        implementation_t* tmp(allocator.allocate(1));
-
-        try {
-            ::new (static_cast<void*>(tmp)) implementation_t(std::move(x));
-        }
-        catch (...) {
-            tmp->get_allocator().deallocate(tmp, 1);
-            throw;
-        }
-
-        return tmp;
-    }
-
-    static void release(implementation_t* x) {
-        /*
-            I thought about returning a bool from this routine (denoting whether
-            or not a deallocation took place) but decided not to in the end.
-            Release's semantics are that of giving up ownership of the
-            implementation instance, so you are not allowed to subsequently
-            interact with the implementation instance you've released. Thus,
-            notifying the caller of a deallocation is a moot point.
-        */
-
-        if (x == 0 || x->header_m.get().count_m.decrement() == false)
-            return;
-
-        implementation_allocator_type allocator(x->get_allocator());
-
-        destroy(x);
-
-        allocator.deallocate(x, 1);
-    }
-
-    void reset(implementation_t* to) {
-        release(object_m);
-        object_m = to;
-    }
-
-    implementation_t* object_m;
-
-    static std::once_flag flag_s;
-    static implementation_t* default_s;
-
-    static void release_default();
-    static void init_default();
-#endif
 };
-
-/**************************************************************************************************/
-
-#if !defined(ADOBE_NO_DOCUMENTATION)
-
-/**************************************************************************************************/
-
-template <typename T, typename A>
-std::once_flag copy_on_write<T, A>::flag_s;
-
-template <typename T, typename A>
-typename copy_on_write<T, A>::implementation_t* copy_on_write<T, A>::default_s;
-
-template <typename T, typename A>
-struct copy_on_write<T, A>::implementation_t : private boost::noncopyable {
-    // Assert proper size for counter_t
-    BOOST_STATIC_ASSERT((sizeof(counter_t) == sizeof(std::size_t)));
-    // Assert proper alignment for counter_t
-    BOOST_STATIC_ASSERT((sizeof(counter_t) == sizeof(void*)));
-
-    struct header_t {
-        counter_t count_m;
-        allocator_type allocator_m;
-    };
-
-    explicit implementation_t(T x) : value_m(std::move(x)) {}
-
-    implementation_allocator_type get_allocator() const {
-        return implementation_allocator_type(header_m.get().allocator_m);
-    }
-
-    aligned_storage<header_t> header_m;
-    value_type value_m;
-};
-
-template <typename T, typename A>
-void copy_on_write<T, A>::init_default() {
-    implementation_allocator_type allocator;
-
-    default_s = allocate(allocator);
-
-    std::atexit(release_default); // ignore failure
-}
-
-template <typename T, typename A>
-void copy_on_write<T, A>::release_default() {
-    release(default_s);
-}
-
-#endif
-
-/**************************************************************************************************/
-
-} // namespace version_1
-
-/**************************************************************************************************/
-
-using version_1::copy_on_write;
-
-/**************************************************************************************************/
-
-#if 0
-template <typename T, typename A> struct is_movable<copy_on_write<T, A> > : boost::mpl::true_ { };
-#endif
-
 /**************************************************************************************************/
 
 } // namespace adobe
@@ -401,3 +256,4 @@ template <typename T, typename A> struct is_movable<copy_on_write<T, A> > : boos
 #endif
 
 /**************************************************************************************************/
+


### PR DESCRIPTION
updated to latest C++
removed boost dependencies
removed other adobe dependencies (stand-alone)
removed ABI stability code
removed allocator support
deprecated unique_instance() - replaced by unique().
fixed bugs (and hopefully didn't introduce any)

Considering migrating to stlab (would add compatibility interface in asl that just included stlab/copy_on_write.hpp and pulled copy_on_write into the adobe namespace.

Also want to review atomic-ops could likely be more optimal using explicit memory order (wouldn't matter for Intel).