### PR TITLE
Remove support for unit tests manual registration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,6 @@ else()
 
     add_library(boost_unit_test STATIC ${ASL_BOOST_TEST_SRC})
 
-    target_include_directories(boost_unit_test PRIVATE -DBOOST_TEST_MAIN)
     foreach (submodule ${BOOST_SUBMODULES})
         target_include_directories(boost_unit_test PUBLIC ../boost_libraries/${submodule}/include)
     endforeach(submodule)


### PR DESCRIPTION
Manual unit test registration has been declared obsolete and deprecated
within Boost unit test framework [1] and replaced by automatic unit test
registration [2] and fixtures [3].

More practical and negative side-effect of having this support included
in the build in its current form is rendering the clang-based tools almost
inoperable because it invalidates the contents of `compile_commands.json`
file. This is _the_ file that clang-based tools rely on in order to
implement their functionality. I.e. current state is that running the
following command in the root of the repository:
- `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .`

will generate a JSON file which contains invalid entries such as:

- `-I/home/jbakamovic/development/projects/adobe_source_libraries/-DBOOST_TEST_MAIN`

Mind the missing space between the include directory and the preprocessor
define.

This is probably a bug in CMake but also a 'bug' in this repository build
rules because `CMakeLists.txt` is confusing `target_include_directories()`
with `target_compile_definitions()` for bringing in the preprocessor
define (in this specific case `-DBOOST_TEST_MAIN`).

[1] http://www.boost.org/doc/libs/1_66_0/libs/test/doc/html/boost_test/adv_scenarios/obsolete_init_func.html
[2] http://www.boost.org/doc/libs/1_66_0/libs/test/doc/html/boost_test/tests_organization/test_cases/test_organization_nullary.html#ref_BOOST_AUTO_TEST_CASE
[3] http://www.boost.org/doc/libs/1_66_0/libs/test/doc/html/boost_test/tests_organization/fixtures.html