### PR TITLE
sean-parent/xstring

### DIFF
--- a/adobe/algorithm/minmax.hpp
+++ b/adobe/algorithm/minmax.hpp
@@ -65,9 +65,9 @@ assert(a == 10);
     \brief minmax implementation
 */
 
-template <class T, class R>
-inline const T&(min)(const T& a, const T& b, R r) {
-    return select_0_2(a, b, std::bind(r, std::placeholders::_1, std::placeholders::_2));
+template <class T, class C>
+inline const T&(min)(const T& a, const T& b, C c) {
+    return select_0_2(a, b, std::bind(c, std::placeholders::_1, std::placeholders::_2));
 }
 
 /*!
@@ -76,9 +76,33 @@ inline const T&(min)(const T& a, const T& b, R r) {
     \brief minmax implementation
 */
 
-template <class T, class R>
-inline T&(min)(T& a, T& b, R r) {
-    return select_0_2(a, b, std::bind(r, std::placeholders::_1, std::placeholders::_2));
+template <class T, class C, class P>
+inline const T&(min)(const T& a, const T& b, C c, P p) {
+    return select_0_2(a, b, std::bind(c, std::bind(p, std::placeholders::_1),
+                                     std::bind(p, std::placeholders::_2)));
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+
+template <class T, class C>
+inline T&(min)(T& a, T& b, C c) {
+    return select_0_2(a, b, std::bind(c, std::placeholders::_1, std::placeholders::_2));
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+
+template <class T, class C, class P>
+inline T&(min)(T& a, T& b, C c, P p) {
+    return select_0_2(a, b, std::bind(c, std::bind(p, std::placeholders::_1),
+                                     std::bind(p, std::placeholders::_2)));
 }
 
 /*!
@@ -109,9 +133,9 @@ inline T&(min)(T& a, T& b) {
     \brief minmax implementation
 */
 
-template <class T, class R>
-inline const T&(max)(const T& a, const T& b, R r) {
-    return select_1_2(a, b, std::bind(r, std::placeholders::_1, std::placeholders::_2));
+template <class T, class C>
+inline const T&(max)(const T& a, const T& b, C c) {
+    return select_1_2(a, b, std::bind(c, std::placeholders::_1, std::placeholders::_2));
 }
 
 /*!
@@ -120,9 +144,34 @@ inline const T&(max)(const T& a, const T& b, R r) {
     \brief minmax implementation
 */
 
-template <class T, class R>
-inline T&(max)(T& a, T& b, R r) {
-    return select_1_2(a, b, std::bind(r, std::placeholders::_1, std::placeholders::_2));
+
+template <class T, class C, class P>
+inline const T&(max)(const T& a, const T& b, C c, P p) {
+    return select_1_2(a, b, std::bind(c, std::bind(p, std::placeholders::_1),
+                                     std::bind(p, std::placeholders::_2)));
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+
+template <class T, class C>
+inline T&(max)(T& a, T& b, C c) {
+    return select_1_2(a, b, std::bind(c, std::placeholders::_1, std::placeholders::_2));
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+
+template <class T, class C, class P>
+inline T&(max)(T& a, T& b, C c, P p) {
+    return select_1_2(a, b, std::bind(c, std::bind(p, std::placeholders::_1),
+                                     std::bind(p, std::placeholders::_2)));
 }
 
 /*!
@@ -174,9 +223,9 @@ min_element(const ForwardRange& range) {
 
     \brief minmax implementation
 */
-template <class ForwardIterator, class R>
-inline ForwardIterator min_element(ForwardIterator first, ForwardIterator last, R r) {
-    return std::min_element(first, last, std::bind(r, std::placeholders::_1, std::placeholders::_2));
+template <class ForwardIterator, class C>
+inline ForwardIterator min_element(ForwardIterator first, ForwardIterator last, C c) {
+    return std::min_element(first, last, std::bind(c, std::placeholders::_1, std::placeholders::_2));
 }
 
 /*!
@@ -184,9 +233,10 @@ inline ForwardIterator min_element(ForwardIterator first, ForwardIterator last, 
 
     \brief minmax implementation
 */
-template <class ForwardRange, class R>
-inline typename boost::range_iterator<ForwardRange>::type min_element(ForwardRange& range, R r) {
-    return adobe::min_element(boost::begin(range), boost::end(range), r);
+template <class ForwardIterator, class C, class P>
+inline ForwardIterator min_element(ForwardIterator first, ForwardIterator last, C c, P p) {
+    return std::min_element(first, last, std::bind(c, std::bind(p, std::placeholders::_1),
+                                     std::bind(p, std::placeholders::_2)));
 }
 
 /*!
@@ -194,10 +244,41 @@ inline typename boost::range_iterator<ForwardRange>::type min_element(ForwardRan
 
     \brief minmax implementation
 */
-template <class ForwardRange, class R>
+template <class ForwardRange, class C>
+inline typename boost::range_iterator<ForwardRange>::type min_element(ForwardRange& range, C c) {
+    return adobe::min_element(boost::begin(range), boost::end(range), c);
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+template <class ForwardRange, class C, class P>
+inline typename boost::range_iterator<ForwardRange>::type min_element(ForwardRange& range, C c, P p) {
+    return adobe::min_element(boost::begin(range), boost::end(range), c, p);
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+template <class ForwardRange, class C>
 inline typename boost::range_const_iterator<ForwardRange>::type
-min_element(const ForwardRange& range, R r) {
-    return adobe::min_element(boost::begin(range), boost::end(range), r);
+min_element(const ForwardRange& range, C c) {
+    return adobe::min_element(boost::begin(range), boost::end(range), c);
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+template <class ForwardRange, class C, class P>
+inline typename boost::range_const_iterator<ForwardRange>::type
+min_element(const ForwardRange& range, C c, P p) {
+    return adobe::min_element(boost::begin(range), boost::end(range), c, p);
 }
 
 /*!
@@ -226,9 +307,9 @@ max_element(const ForwardRange& range) {
 
     \brief minmax implementation
 */
-template <class ForwardIterator, class R>
-inline ForwardIterator max_element(ForwardIterator first, ForwardIterator last, R r) {
-    return std::max_element(first, last, std::bind(r, std::placeholders::_1, std::placeholders::_2));
+template <class ForwardIterator, class C>
+inline ForwardIterator max_element(ForwardIterator first, ForwardIterator last, C c) {
+    return std::max_element(first, last, std::bind(c, std::placeholders::_1, std::placeholders::_2));
 }
 
 /*!
@@ -236,9 +317,10 @@ inline ForwardIterator max_element(ForwardIterator first, ForwardIterator last, 
 
     \brief minmax implementation
 */
-template <class ForwardRange, class R>
-inline typename boost::range_iterator<ForwardRange>::type max_element(ForwardRange& range, R r) {
-    return adobe::max_element(boost::begin(range), boost::end(range), r);
+template <class ForwardIterator, class C, class P>
+inline ForwardIterator max_element(ForwardIterator first, ForwardIterator last, C c, P p) {
+    return std::max_element(first, last, std::bind(c, std::bind(p, std::placeholders::_1),
+                                     std::bind(p, std::placeholders::_2)));
 }
 
 /*!
@@ -246,10 +328,41 @@ inline typename boost::range_iterator<ForwardRange>::type max_element(ForwardRan
 
     \brief minmax implementation
 */
-template <class ForwardRange, class R>
+template <class ForwardRange, class C>
+inline typename boost::range_iterator<ForwardRange>::type max_element(ForwardRange& range, C c) {
+    return adobe::max_element(boost::begin(range), boost::end(range), c);
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+template <class ForwardRange, class C, class P>
+inline typename boost::range_iterator<ForwardRange>::type max_element(ForwardRange& range, C c, P p) {
+    return adobe::max_element(boost::begin(range), boost::end(range), c, p);
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+template <class ForwardRange, class C>
 inline typename boost::range_const_iterator<ForwardRange>::type
-max_element(const ForwardRange& range, R r) {
-    return adobe::max_element(boost::begin(range), boost::end(range), r);
+max_element(const ForwardRange& range, C c) {
+    return adobe::max_element(boost::begin(range), boost::end(range), c);
+}
+
+/*!
+    \ingroup minmax
+
+    \brief minmax implementation
+*/
+template <class ForwardRange, class C, class P>
+inline typename boost::range_const_iterator<ForwardRange>::type
+max_element(const ForwardRange& range, C c, P p) {
+    return adobe::max_element(boost::begin(range), boost::end(range), c, p);
 }
 
 /*************************************************************************************************/

--- a/adobe/iterator.hpp
+++ b/adobe/iterator.hpp
@@ -3,7 +3,7 @@
     Distributed under the Boost Software License, Version 1.0.
     (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 #ifndef ADOBE_ITERATOR_HPP
 #define ADOBE_ITERATOR_HPP
@@ -32,7 +32,7 @@
 
 namespace adobe {
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 /*
     Just counts the number of outputs; doesn't copy anything. More efficient than a
@@ -40,7 +40,7 @@ namespace adobe {
     the result.
 */
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 /*!
 \addtogroup adobe_iterator
@@ -82,7 +82,24 @@ private:
     std::size_t count_m;
 };
 
-/*************************************************************************************************/
+/**************************************************************************************************/
+
+struct null_output_t {
+    using iterator_category = std::output_iterator_tag;
+
+    using value_type = void;
+    using difference_type = void;
+    using pointer = void;
+    using reference = void;
+
+    constexpr null_output_t& operator++(int) { return *this; }
+    constexpr null_output_t& operator++() { return *this; }
+    constexpr null_output_t& operator*() { return *this; }
+    template <class T>
+    constexpr null_output_t& operator=(const T&) { return *this; }
+};
+
+/**************************************************************************************************/
 
 /*
     top iterator            bottom iterator
@@ -222,7 +239,7 @@ inline segmented_iterator<typename boost::range_iterator<R>::type> make_segmente
     return iterator(boost::begin(r), boost::end(r));
 }
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 /*
     NOTE (sparent) : The asserts are comment only because we don't require that our function
@@ -390,7 +407,7 @@ inline bool operator!=(const step_iterator_adaptor<D, IT, S_FN>& p1,
     return p1.base() != p2.base();
 }
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 /*!
     \brief A stub iterator that models OutputIterator and outputs nothing.
@@ -414,12 +431,12 @@ struct null_output_iterator_t {
 
 //! @}
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 } // namespace adobe
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 #endif
 
-/*************************************************************************************************/
+/**************************************************************************************************/

--- a/adobe/iterator.hpp
+++ b/adobe/iterator.hpp
@@ -25,6 +25,8 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 
+#include <adobe/iterator/null_output.hpp>
+
 #include <adobe/typeinfo.hpp>
 #include <adobe/empty.hpp>
 
@@ -80,23 +82,6 @@ public:
 
 private:
     std::size_t count_m;
-};
-
-/**************************************************************************************************/
-
-struct null_output_t {
-    using iterator_category = std::output_iterator_tag;
-
-    using value_type = void;
-    using difference_type = void;
-    using pointer = void;
-    using reference = void;
-
-    constexpr null_output_t& operator++(int) { return *this; }
-    constexpr null_output_t& operator++() { return *this; }
-    constexpr null_output_t& operator*() { return *this; }
-    template <class T>
-    constexpr null_output_t& operator=(const T&) { return *this; }
 };
 
 /**************************************************************************************************/

--- a/adobe/iterator/null_output.hpp
+++ b/adobe/iterator/null_output.hpp
@@ -1,0 +1,44 @@
+/*
+    Copyright 2013 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+/**************************************************************************************************/
+
+#ifndef ADOBE_ITERATOR_NULL_OUTPUT_HPP
+#define ADOBE_ITERATOR_NULL_OUTPUT_HPP
+
+#include <iterator>
+
+/**************************************************************************************************/
+
+namespace adobe {
+
+/**************************************************************************************************/
+
+struct null_output_t {
+    using iterator_category = std::output_iterator_tag;
+
+    using value_type = void;
+    using difference_type = void;
+    using pointer = void;
+    using reference = void;
+
+    constexpr null_output_t& operator++(int) { return *this; }
+    constexpr null_output_t& operator++() { return *this; }
+    constexpr null_output_t& operator*() { return *this; }
+
+    template <class T>
+    constexpr null_output_t& operator=(const T&) {
+        return *this;
+    }
+};
+
+/**************************************************************************************************/
+
+} // namespace adobe
+
+/**************************************************************************************************/
+
+#endif
+// ADOBE_ITERATOR_NULL_OUTPUT_HPP

--- a/adobe/xml_parser.hpp
+++ b/adobe/xml_parser.hpp
@@ -12,17 +12,19 @@
 
 #include <adobe/config.hpp>
 
-#include <adobe/any_regular.hpp>
 #include <adobe/algorithm/set.hpp>
-#include <adobe/istream.hpp>
+#include <adobe/any_regular.hpp>
 #include <adobe/array.hpp>
 #include <adobe/copy_on_write.hpp>
-#include <adobe/name.hpp>
 #include <adobe/dictionary.hpp>
+#include <adobe/istream.hpp>
+#include <adobe/iterator/null_output.hpp>
+#include <adobe/name.hpp>
 #include <adobe/string.hpp>
+
+#include <adobe/implementation/parser_shared.hpp>
 #include <adobe/implementation/xml_lex.hpp>
 #include <adobe/implementation/xml_token.hpp>
-#include <adobe/implementation/parser_shared.hpp>
 
 #include <boost/function.hpp>
 #include <boost/noncopyable.hpp>

--- a/adobe/xstring.hpp
+++ b/adobe/xstring.hpp
@@ -13,12 +13,14 @@
 #include <adobe/config.hpp>
 
 #include <adobe/functional.hpp>
-#include <adobe/implementation/string_pool.hpp>
 #include <adobe/istream.hpp>
+#include <adobe/iterator/null_output.hpp>
 #include <adobe/name.hpp>
 #include <adobe/string.hpp>
 #include <adobe/unicode.hpp>
 #include <adobe/xml_parser.hpp>
+
+#include <adobe/implementation/string_pool.hpp>
 
 #include <boost/bind.hpp>
 #include <boost/core/ref.hpp>

--- a/adobe/xstring.hpp
+++ b/adobe/xstring.hpp
@@ -51,25 +51,6 @@ inline bool xstring_preorder_predicate(const token_range_t& range) {
 
 /**************************************************************************************************/
 
-struct null_output_t {
-    typedef std::output_iterator_tag iterator_category;
-    typedef null_output_t value_type;
-    typedef std::ptrdiff_t difference_type;
-    typedef value_type* pointer;
-    typedef value_type& reference;
-
-    null_output_t& operator++(int) { return *this; }
-    null_output_t& operator++() { return *this; }
-    reference operator*() { return *this; }
-
-    template <typename T>
-    null_output_t& operator=(const T&) {
-        return *this;
-    }
-};
-
-/**************************************************************************************************/
-
 token_range_t xml_xstr_store(const token_range_t& entire_element_range, const token_range_t& name,
                              const attribute_set_t& attribute_set, const token_range_t& value);
 
@@ -315,7 +296,7 @@ private:
 
         make_xml_parser(context.slurp_m.first, context.slurp_m.second, context.parse_info_m,
                         implementation::xstring_preorder_predicate, &implementation::xml_xstr_store,
-                        implementation::null_output_t())
+                        null_output_t())
             .parse_element_sequence(); // REVISIT (fbrereto) : More or less legible than having it
         // after the above declaration?
 
@@ -333,8 +314,8 @@ private:
 #ifdef __ADOBE_COMPILER_CONCEPTS__
 namespace std {
 // It would be nice to be able to instantiate this for all T. Not sure why it doesn't work.
-concept_map OutputIterator<adobe::implementation::null_output_t, char>{};
-concept_map OutputIterator<adobe::implementation::null_output_t, unsigned char>{};
+concept_map OutputIterator<adobe::null_output_t, char>{};
+concept_map OutputIterator<adobe::null_output_t, unsigned char>{};
 }
 #endif
 

--- a/adobe/xstring.hpp
+++ b/adobe/xstring.hpp
@@ -3,12 +3,12 @@
     Distributed under the Boost Software License, Version 1.0.
     (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 #ifndef ADOBE_XSTRING_HPP
 #define ADOBE_XSTRING_HPP
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 #include <adobe/config.hpp>
 
@@ -20,9 +20,10 @@
 #include <adobe/unicode.hpp>
 #include <adobe/xml_parser.hpp>
 
-#include <boost/function.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/bind.hpp>
+#include <boost/core/ref.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/range/size.hpp>
 
 #include <sstream>
 #include <vector>
@@ -30,15 +31,15 @@
 #include <cassert>
 #include <cctype>
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 namespace adobe {
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 namespace implementation {
 
-/****************************************************************************************************/
+/**************************************************************************************************/
 
 inline bool xstring_preorder_predicate(const token_range_t& range) {
     // we want to check for both xstr and marker tags because both are
@@ -48,7 +49,7 @@ inline bool xstring_preorder_predicate(const token_range_t& range) {
            token_range_equal(range, static_token_range("marker"));
 }
 
-/****************************************************************************************************/
+/**************************************************************************************************/
 
 struct null_output_t {
     typedef std::output_iterator_tag iterator_category;
@@ -67,7 +68,7 @@ struct null_output_t {
     }
 };
 
-/****************************************************************************************************/
+/**************************************************************************************************/
 
 token_range_t xml_xstr_store(const token_range_t& entire_element_range, const token_range_t& name,
                              const attribute_set_t& attribute_set, const token_range_t& value);
@@ -79,7 +80,7 @@ token_range_t xml_element_finalize(const token_range_t& entire_element_range,
                                    const token_range_t& name, const attribute_set_t& attribute_set,
                                    const token_range_t& value);
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 struct context_frame_t {
     struct comp_t {
@@ -161,27 +162,27 @@ struct context_frame_t {
     unique_string_pool_t pool_m;
 };
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 inline bool operator==(const context_frame_t::element_t& x, const context_frame_t::element_t& y) {
     return x.first == y.first && token_range_equal(x.second, y.second);
 }
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 implementation::context_frame_t& top_frame();
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 } // namespace implementation
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 #ifndef NDEBUG
 
 void xstring_clear_glossary();
 
 #endif
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 // XML fragment parsing
 
@@ -209,7 +210,7 @@ inline void parse_xml_fragment(const char* fragment, O output) {
                               output);
 }
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 // xstring lookup with OutputIterator; all of these functions return a valid XML fragment
 
@@ -223,7 +224,7 @@ inline void xstring(const char* xstr, O output) {
     xstring(xstr, std::strlen(xstr), output);
 }
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 // xstring lookup; all of these functions return a valid XML fragment
 
@@ -237,7 +238,7 @@ inline std::string xstring(const char* xstr, std::size_t n) {
 
 inline std::string xstring(const std::string& xstr) { return xstring(xstr.c_str(), xstr.size()); }
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 // Context-sensitive marker replacement
 
@@ -251,7 +252,7 @@ std::string xstring_replace(const name_t& xstr_id, const std::string& marker);
 std::string xstring_replace(const name_t& xstr_id, const std::string* first,
                             const std::string* last);
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 struct xstring_context_t : boost::noncopyable {
     typedef implementation::context_frame_t::callback_proc_t callback_proc_t;
@@ -324,11 +325,11 @@ private:
     implementation::context_frame_t back_frame_m;
 };
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 } // namespace adobe
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 #ifdef __ADOBE_COMPILER_CONCEPTS__
 namespace std {
 // It would be nice to be able to instantiate this for all T. Not sure why it doesn't work.
@@ -337,8 +338,8 @@ concept_map OutputIterator<adobe::implementation::null_output_t, unsigned char>{
 }
 #endif
 
-/*************************************************************************************************/
+/**************************************************************************************************/
 
 #endif
 
-/*************************************************************************************************/
+/**************************************************************************************************/

--- a/source/xstring.cpp
+++ b/source/xstring.cpp
@@ -11,10 +11,12 @@
 #include <adobe/algorithm/find_match.hpp>
 #include <adobe/algorithm/minmax.hpp>
 #include <adobe/dictionary.hpp>
-#include <adobe/implementation/string_pool.hpp>
 #include <adobe/istream.hpp>
+#include <adobe/iterator/null_output.hpp>
 #include <adobe/name.hpp>
 #include <adobe/once.hpp>
+
+#include <adobe/implementation/string_pool.hpp>
 
 #include <boost/cstdint.hpp>
 #include <boost/bind.hpp>

--- a/source/xstring.cpp
+++ b/source/xstring.cpp
@@ -472,7 +472,7 @@ struct replacement_engine_t {
             adobe::line_position_t("replacement_engine_t"),
             adobe::implementation::xstring_preorder_predicate,
             boost::bind(&replacement_engine_t::xstr_id_harvest, boost::ref(*this), _1, _2, _3, _4),
-            adobe::implementation::null_output_t()).parse_content();
+            adobe::null_output_t()).parse_content();
     }
 
     void add_marker(const std::string& marker) {
@@ -481,7 +481,7 @@ struct replacement_engine_t {
             reinterpret_cast<uchar_ptr_t>(&marker[0]) + marker.size(),
             adobe::line_position_t("add_marker"), adobe::implementation::xstring_preorder_predicate,
             boost::bind(&replacement_engine_t::marker_parse, boost::ref(*this), _1, _2, _3, _4),
-            adobe::implementation::null_output_t()).parse_content();
+            adobe::null_output_t()).parse_content();
     }
 
     std::string run() {

--- a/test/xml_parser/main.cpp
+++ b/test/xml_parser/main.cpp
@@ -8,8 +8,8 @@
 
 #include <adobe/config.hpp>
 
+#include <adobe/iterator/null_output.hpp>
 #include <adobe/xml_parser.hpp>
-#include <adobe/xstring.hpp>
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
@@ -147,7 +147,7 @@ long calculate_expression(const adobe::token_range_t& content) {
     adobe::make_xml_parser(content.first, content.second, adobe::line_position_t("expression"),
                            adobe::always_true<adobe::token_range_t>(),
                            boost::bind(expression_content, _1, _2, _3, _4, boost::ref(value_stack)),
-                           adobe::implementation::null_output_t()).parse_content();
+                           adobe::null_output_t()).parse_content();
 
     return value_stack.back();
 }
@@ -166,7 +166,7 @@ adobe::token_range_t document_content(const adobe::token_range_t& /*entire_eleme
         adobe::make_xml_parser(value.first, value.second, adobe::line_position_t("math-test"),
                                adobe::always_true<adobe::token_range_t>(),
                                boost::bind(test_content, _1, _2, _3, _4, boost::ref(test)),
-                               adobe::implementation::null_output_t()).parse_content();
+                               adobe::null_output_t()).parse_content();
 
         if (test.observed_m == test.expected_m)
             passed = true;
@@ -248,7 +248,7 @@ bool run_test(const adobe::token_range_t& document, const adobe::line_position_t
     adobe::make_xml_parser(document.first, document.second, line_position,
                            adobe::always_true<adobe::token_range_t>(),
                            boost::bind(document_content, _1, _2, _3, _4, boost::ref(passed)),
-                           adobe::implementation::null_output_t()).parse_document();
+                           adobe::null_output_t()).parse_document();
 
     return passed;
 }


### PR DESCRIPTION
I removed the use of transform iterators (broken because the transform returned a value instead of a reference and so decayed to an input iterator). Now uses a projecting comparison. Added projection support to minmax.