### PR TITLE
Add missing <mutex> header when using gcc 6 on Linux

### DIFF
--- a/source/xstring.cpp
+++ b/source/xstring.cpp
@@ -21,6 +21,8 @@
 #include <boost/cstdint.hpp>
 #include <boost/bind.hpp>
 
+#include <mutex>
+
 #if !defined(NDEBUG) && defined(ADOBE_SERIALIZATION)
 #define ADOBE_DOING_SERIALIZATION 1
 #endif


### PR DESCRIPTION
extern/asl/source/xstring.cpp: In function ‘void {anonymous}::xstr_once()’:
extern/asl/source/xstring.cpp:125:12: error: ‘once_flag’ does not name a type
     static once_flag flag;
            ^~~~~~~~~
extern/asl/source/xstring.cpp:126:15: error: ‘flag’ was not declared in this scope
     call_once(flag, &init_xstr_once);
               ^~~~
extern/asl/source/xstring.cpp:126:36: error: ‘call_once’ was not declared in this scope
     call_once(flag, &init_xstr_once);
                                    ^
make[3]: *** [extern/CMakeFiles/asl.dir/build.make:544: extern/CMakeFiles/asl.dir/asl/source/xstring.cpp.o] Error 1