### PR TITLE
Adding namespace to avoid conflict with C++20 construct_at

### DIFF
--- a/adobe/any_regular.hpp
+++ b/adobe/any_regular.hpp
@@ -287,8 +287,8 @@ struct any_regular_model_remote : any_regular_interface_t, boost::noncopyable {
     static object_t* new_move(T& x) {
         allocator_type a;
         object_t* result = a.allocate(1);
-        construct_at(&result->alloc_m, aligned_storage<allocator_type>(a));
-        construct_at(&result->data_m, std::move(x));
+        adobe::construct_at(&result->alloc_m, aligned_storage<allocator_type>(a));
+        adobe::construct_at(&result->data_m, std::move(x));
         return result;
     }
 

--- a/adobe/closed_hash.hpp
+++ b/adobe/closed_hash.hpp
@@ -543,9 +543,9 @@ private:
             alloc.allocate(sizeof(header_t) - sizeof(node_t) + sizeof(node_t) * n));
         header()->capacity() = n;
         header()->size() = 0;
-        construct_at(&header()->free_tail());
-        construct_at(&header()->used_tail());
-        construct_at(&header()->allocator(), a);
+        adobe::construct_at(&header()->free_tail());
+        adobe::construct_at(&header()->used_tail());
+        adobe::construct_at(&header()->allocator(), a);
 
         node_t* prior = header()->free_tail().address();
         for (node_ptr first(&header()->storage_m[0]), last(&header()->storage_m[0] + n);
@@ -582,7 +582,7 @@ private:
 
     // location points to a free node
     static void insert_raw(iterator location, value_type x, std::size_t state) {
-        construct_at<value_type>(&*location, std::move(x));
+        adobe::construct_at<value_type>(&*location, std::move(x));
         location.set_state(state);
         unsafe::skip_node(location);
     }

--- a/adobe/memory.hpp
+++ b/adobe/memory.hpp
@@ -353,21 +353,10 @@ inline void destroy(T* p) {
     https://en.cppreference.com/w/cpp/memory/construct_at
 */
 
-#if __cplusplus < 202002L
-
 template <class T, class... Args>
-constexpr T* construct_at(T* p, Args&&... args) {
-    return ::new (const_cast<void*>(static_cast<const volatile void*>(p)))
-        T(std::forward<Args>(args)...);
+T* construct_at(T* p, Args&&... args) {
+    return ::new (static_cast<void*>(p)) T(std::forward<Args>(args)...);
 }
-
-#else
-
-template <class T, class... Args>
-auto construct_at(T* p, Args&&... args) -> decltype(std::construct_at(p, std::forward<Args>(args)...)) {
-    return std::construct_at(p, std::forward<Args>(args)...);
-}
-#endif
 
 template <typename T, typename U> // T models Regular
 [[deprecated("Use adobe::construct_at(p, x)")]] constexpr auto construct(T* p, U&& x) {

--- a/adobe/memory.hpp
+++ b/adobe/memory.hpp
@@ -362,11 +362,9 @@ constexpr T* construct_at(T* p, Args&&... args) {
 }
 
 #else
-
-template <class T, class... Args>
-constexpr T* construct_at(T* p, Args&&... args) {
-    return std::construct_at(T * p, Args && ... args) {}
-
+auto construct_at(T* p, Args&&... args) -> decltype(std::construct_at(p, std::forward<Args>(args)...)) {
+    return std::construct_at(p, std::forward<Args>(args)...);
+}
 #endif
 
 template <typename T, typename U> // T models Regular

--- a/adobe/memory.hpp
+++ b/adobe/memory.hpp
@@ -362,6 +362,8 @@ constexpr T* construct_at(T* p, Args&&... args) {
 }
 
 #else
+
+template <class T, class... Args>
 auto construct_at(T* p, Args&&... args) -> decltype(std::construct_at(p, std::forward<Args>(args)...)) {
     return std::construct_at(p, std::forward<Args>(args)...);
 }


### PR DESCRIPTION
With C++20 I was getting compilation errors because of ambiguity in selecting `construct_at`, `construct_at` is defined in both `std` & `adobe` namespace.