### PR TITLE
Clang Static Analyzer Fixes

### DIFF
--- a/adobe/future.hpp
+++ b/adobe/future.hpp
@@ -30,7 +30,7 @@ struct any_packaged_task_ {
     any_packaged_task_() = default;
 
     template <typename T>
-    any_packaged_task_(T&& task) : object_(new model_<T>(std::move(task))) {}
+    any_packaged_task_(T&& task) : object_(new model_<T>(std::forward<T>(task))) {}
 
     any_packaged_task_(any_packaged_task_&& x) noexcept = default;
     any_packaged_task_& operator=(any_packaged_task_&& x) noexcept = default;

--- a/test/closed_hash/main.cpp
+++ b/test/closed_hash/main.cpp
@@ -39,12 +39,18 @@ void test_movable(const T& x) {
     // move construction (and RVO)
     const void* addr = remote_address(y);
     T z = std::move(y);
+#ifndef __clang_analyzer__
+    // Use after move
     BOOST_CHECK(y == T());
+#endif
     BOOST_CHECK(z == x);
     BOOST_CHECK(remote_address(z) == addr);
     // move assignment
     y = std::move(z);
+#ifndef __clang_analyzer__
+    // Use after move
     BOOST_CHECK(z == T());
+#endif
     BOOST_CHECK(y == x);
     BOOST_CHECK(remote_address(y) == addr);
 }
@@ -158,7 +164,7 @@ BOOST_AUTO_TEST_CASE(closed_hash) {
         x.reserve(2 * x.capacity());
         BOOST_CHECK(x.capacity() > c);
         BOOST_CHECK(x.size() == 3);
-        BOOST_CHECK(addr = remote_address(x.find(2)->second));
+        BOOST_CHECK(addr == remote_address(x.find(2)->second));
     }
 
 #if 0

--- a/test/unit_tests/conversion/conversion_test.cpp
+++ b/test/unit_tests/conversion/conversion_test.cpp
@@ -33,7 +33,8 @@ BOOST_AUTO_TEST_CASE(conversion_test) {
     using adobe::runtime_cast;
 
     {
-        base* x = new derived;
+        derived d;
+        base* x = &d;
         BOOST_CHECK(runtime_cast<derived*>(x));
         BOOST_CHECK(runtime_cast<const derived*>(x));
         // BOOST_CHECK(runtime_cast<not_derived*>(x));
@@ -44,7 +45,8 @@ BOOST_AUTO_TEST_CASE(conversion_test) {
     }
 
     {
-        const base* x = new derived;
+        const derived d;
+        const base* x = &d;
         // BOOST_CHECK(runtime_cast<derived*>(x));
         BOOST_CHECK(runtime_cast<const derived*>(x));
         derived y = runtime_cast<const derived&>(*x);

--- a/test/unit_tests/copy_on_write/cow_test.cpp
+++ b/test/unit_tests/copy_on_write/cow_test.cpp
@@ -197,12 +197,18 @@ void test_copy_on_write() {
         CowType value_2(mv(21)); // allocation
         CowType value_move(std::move(value_1));
 
+#ifndef __clang_analyzer__
+        // Use after move
         BOOST_CHECK_MESSAGE(value_move != value_1, "move failure");
+#endif
 
         value_move = std::move(value_2); // deallocation
 
+#ifndef __clang_analyzer__
+        // Use after move
         BOOST_CHECK_MESSAGE(value_move != value_2, "move failure");
         BOOST_CHECK_MESSAGE(value_1 == value_2, "move failure"); // both should be object_m == 0
+#endif
     }
     // Check
     if (is_noisy) {


### PR DESCRIPTION
Fixed all the issues reported by clang-static-analyzer. Disabled analyzer for use-after-move-in unit tests where stronger guarantees are provided.