### PR TITLE
Fixing some symbol names and compilation breaks in other code

### DIFF
--- a/adobe/enum_ops.hpp
+++ b/adobe/enum_ops.hpp
@@ -9,6 +9,7 @@
 #define ADOBE_ENUM_OPS_HPP
 
 /**************************************************************************************************/
+
 #include <type_traits>
 
 /**************************************************************************************************/
@@ -25,11 +26,11 @@
     defined for an enumeration type, \c E, the result will be of type \c E exactly when the
     operand(s) are of type \c E.
 
-    \c ADOBE_DEFINE_BITSET_OPS(E) or auto stlab_enable_bitmask_enum(E) -> std::true_type;
+    \c ADOBE_DEFINE_BITSET_OPS(E) or auto adobe_enable_bitmask_enum(E) -> std::true_type;
     enables the bitset operations <code>~, |, &, ^, |=, &=, ^= </code>
     for enumeration type \c E.
 
-    \c ADOBE_DEFINE_ARITHMETIC_OPS(E) or auto stlab_enable_arithmetic_enum(E) -> std::true_type;
+    \c ADOBE_DEFINE_ARITHMETIC_OPS(E) or auto adobe_enable_arithmetic_enum(E) -> std::true_type;
     enables the typesafe arithmetic operations <code>+, -, *, /,
     %, +=, *=, -=, /=, \%=</code> for enumeration type \c E.
 
@@ -58,8 +59,8 @@ namespace adobe {
 
 /**************************************************************************************************/
 
-auto stlab_enable_bitmask_enum(...) -> std::false_type;
-auto stlab_enable_arithmetic_enum(...) -> std::false_type;
+auto adobe_enable_bitmask_enum(...) -> std::false_type;
+auto adobe_enable_arithmetic_enum(...) -> std::false_type;
 
 /**************************************************************************************************/
 
@@ -69,10 +70,10 @@ namespace implementation {
 
 #if !defined(ADOBE_NO_DOCUMENTATION)
 template <typename T>
-constexpr bool has_enabled_bitmask = decltype(stlab_enable_bitmask_enum(std::declval<T>()))::value;
+constexpr bool has_enabled_bitmask = decltype(adobe_enable_bitmask_enum(std::declval<T>()))::value;
 template <typename T>
 constexpr bool has_enabled_arithmetic =
-    decltype(stlab_enable_arithmetic_enum(std::declval<T>()))::value;
+    decltype(adobe_enable_arithmetic_enum(std::declval<T>()))::value;
 #endif
 
 /**************************************************************************************************/
@@ -87,7 +88,7 @@ constexpr bool has_enabled_arithmetic =
 
 // this exist to mantain backwards compatability with the old ops
 #define ADOBE_DEFINE_BITSET_OPS(EnumType)                                                          \
-    constexpr auto stlab_enable_bitmask_enum(EnumType)->std::true_type;
+    constexpr auto adobe_enable_bitmask_enum(EnumType)->std::true_type;
 
 
 template <typename T>
@@ -138,7 +139,7 @@ constexpr auto operator|=(T& lhs, const T rhs)
 
 // this exist to mantain backwards compatability with the old ops
 #define ADOBE_DEFINE_ARITHMETIC_OPS(EnumType)                                                      \
-    constexpr auto stlab_enable_arithmetic_enum(EnumType)->std::true_type;
+    constexpr auto adobe_enable_arithmetic_enum(EnumType)->std::true_type;
 template <typename T>
 constexpr auto operator+(const T a)
     -> std::enable_if_t<adobe::implementation::has_enabled_arithmetic<T>, T> {

--- a/adobe/widget_attributes.hpp
+++ b/adobe/widget_attributes.hpp
@@ -84,7 +84,7 @@ ADOBE_DEFINE_BITSET_OPS(theme_t)
     behaviors
 */
 
-enum modifiers_t {
+enum modifiers_t : std::uint32_t {
     /// No modifiers
     modifiers_none_s = 0,
 
@@ -114,13 +114,13 @@ enum modifiers_t {
     modifiers_any_command_s = 1 << 7,
 
     /// Any shift key
-    modifiers_any_shift_s = modifiers_left_shift_s | modifiers_right_shift_s,
+    modifiers_any_shift_s = static_cast<std::underlying_type_t<modifiers_t>>(modifiers_left_shift_s) | static_cast<std::underlying_type_t<modifiers_t>>(modifiers_right_shift_s),
 
     /// Any option (or alt) key (if applicable)
-    modifiers_any_option_s = modifiers_left_option_s | modifiers_right_option_s,
+    modifiers_any_option_s = static_cast<std::underlying_type_t<modifiers_t>>(modifiers_left_option_s) | static_cast<std::underlying_type_t<modifiers_t>>(modifiers_right_option_s),
 
     /// Any control key (if applicable)
-    modifiers_any_control_s = modifiers_left_control_s | modifiers_right_control_s,
+    modifiers_any_control_s = static_cast<std::underlying_type_t<modifiers_t>>(modifiers_left_control_s) | static_cast<std::underlying_type_t<modifiers_t>>(modifiers_right_control_s),
     modifiers_all_s = UINT_MAX
 };
 

--- a/test/unit_tests/enum_ops/enum_ops_test.cpp
+++ b/test/unit_tests/enum_ops/enum_ops_test.cpp
@@ -39,7 +39,7 @@ enum class Num : int {
     num_7 = 7
 };
 
-auto stlab_enable_bitmask_enum(Views) -> std::true_type;
+auto adobe_enable_bitmask_enum(Views) -> std::true_type;
 
 ADOBE_DEFINE_BITSET_OPS(Number)
 
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(enumclass_bitset_ops) {
 
 
 ADOBE_DEFINE_ARITHMETIC_OPS(Number)
-auto stlab_enable_arithmetic_enum(Num) -> std::true_type;
+auto adobe_enable_arithmetic_enum(Num) -> std::true_type;
 
 BOOST_AUTO_TEST_CASE(enum_arith_ops) {
     Number x;


### PR DESCRIPTION
Two fixes in this PR:

- Rename `stlab*` symbols to `adobe*` in `enum_ops.hpp` so it does not conflict with stlab's definitions when the two libraries coexist.
- Changing some definitions in `modifiers_t` so it will compile correctly when used by MSVC. There are some long-defunct Adobe Platform Libraries files that we still have to compile (unfortunately) that are now breaking when using newer releases of ASL & MSVC:
```[2024-06-28T02:41:28.820Z] [MB: 16028ms][DEBUG] [9]D:\path\to\adobe_platform_libraries\adobe\future\widgets\sources\button_helper.cpp(41,65): error C2440: 'return': cannot convert from 'int' to 'adobe::modifiers_t' [D:\path\to\adobe_platform_libraries.vcxproj]```
This fixes those compiler breaks long enough for us to revisit and remove those APL dependencies in a latter phase of our work.

These changes are on behalf of @baheath, who did the lion's share of compiler wrangling.