### PR TITLE
Fix to compilation failure with MSVS 17.6

### DIFF
--- a/adobe/serializable.hpp
+++ b/adobe/serializable.hpp
@@ -54,7 +54,7 @@ template <class T, class Stream>
 struct has_stream_insertion : decltype(implementation::test_stream_insertion<T, Stream>(0)) {};
 
 template <class T>
-using has_ostream_insertion = has_stream_insertion<T, std::ostream&>;
+using has_ostream_insertion = has_stream_insertion<T, std::ostream>;
 
 /**************************************************************************************************/
 


### PR DESCRIPTION
Error	C2678	binary '<<': no operator found which takes a left-hand operand of type 'std::ostream' (or there is no acceptable conversion)	adobe_source_libraries\adobe\serializable.hpp	58	

reference was unnecessary in partial template specialisation.