### PR TITLE
For C++20 use keyword `requires` instead of SFINAE magic

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -1,28 +1,46 @@
 {
     "config": [
         {
-            "name": "Linux GCC 11",
+            "name": "Linux GCC 11 C++17",
             "compiler": "gcc",
             "version": "11",
-            "os": "ubuntu-22.04"
+            "os": "ubuntu-22.04",
+            "cxxstd" : "17"
         },
         {
-            "name": "Linux Clang 14",
+            "name": "Linux GCC 11 C++20",
+            "compiler": "gcc",
+            "version": "11",
+            "os": "ubuntu-22.04",
+            "cxxstd" : "20"
+        },
+        {
+            "name": "Linux Clang 14 C++17",
             "compiler": "clang",
             "version": "14",
-            "os": "ubuntu-22.04"
+            "os": "ubuntu-22.04",
+            "cxxstd" : "17"
+        },
+        {
+            "name": "Linux Clang 14 C++20",
+            "compiler": "clang",
+            "version": "14",
+            "os": "ubuntu-22.04",
+            "cxxstd" : "20"
         },
         {
             "name": "macOS apple-clang 14.3.1",
             "compiler": "apple-clang",
             "version": "14.3.1",
-            "os": "macos-13"
+            "os": "macos-13",
+            "cxxstd" : "17"
         },
         {
             "name": "Windows VS2022",
             "compiler": "Visual Studio",
             "version": "17.4",
-            "os": "windows-2022"
+            "os": "windows-2022",
+            "cxxstd" : "17"
         }
     ]
 }

--- a/.github/workflows/adobe_source_libraries.yml
+++ b/.github/workflows/adobe_source_libraries.yml
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         run: |
           mkdir ../build
-          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17
+          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20
 
       - name: Configure (MacOS)
         if: ${{ startsWith(matrix.config.os, 'macos') }}
@@ -115,7 +115,7 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           mkdir ..\build
-          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBOOST_TEST_DYN_LINK=TRUE
+          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBOOST_TEST_DYN_LINK=TRUE
 
       - name: Build (Unix)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') || startsWith(matrix.config.os, 'macos') }}

--- a/.github/workflows/adobe_source_libraries.yml
+++ b/.github/workflows/adobe_source_libraries.yml
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         run: |
           mkdir ../build
-          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20
+          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=${{matrix.config.cxxstd}}
 
       - name: Configure (MacOS)
         if: ${{ startsWith(matrix.config.os, 'macos') }}

--- a/.github/workflows/adobe_source_libraries.yml
+++ b/.github/workflows/adobe_source_libraries.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           mkdir ..\build
-          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBOOST_TEST_DYN_LINK=TRUE
+          cmake -S. -B../build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBOOST_TEST_DYN_LINK=TRUE
 
       - name: Build (Unix)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') || startsWith(matrix.config.os, 'macos') }}

--- a/adobe/serializable.hpp
+++ b/adobe/serializable.hpp
@@ -20,7 +20,7 @@
 /**************************************************************************************************/
 
 namespace adobe {
-
+#if __cplusplus < 202002L
 /**************************************************************************************************/
 
 namespace implementation {
@@ -62,6 +62,16 @@ ostream_insertion(std::ostream& s, const T& x) {
 template <class T>
 inline typename std::enable_if<!has_ostream_insertion<T>::value>::type
 ostream_insertion(std::ostream&, const T&) {}
+
+#else // __cplusplus < 202002L
+
+template <class T>
+void ostream_insertion(std::ostream& s, const T& x) {
+    if constexpr (requires { s << x; }) {
+        s << x;
+    }
+}
+#endif // __cplusplus < 202002L
 
 template <>
 inline void ostream_insertion<bool>(std::ostream& s, const bool& x) {

--- a/adobe/serializable.hpp
+++ b/adobe/serializable.hpp
@@ -49,7 +49,7 @@ template <class T, class Stream>
 struct has_stream_insertion : decltype(implementation::test_stream_insertion<T, Stream>(0)) {};
 
 template <class T>
-using has_ostream_insertion = has_stream_insertion<T, std::ostream>;
+using has_ostream_insertion = has_stream_insertion<T, std::ostream&>;
 
 /**************************************************************************************************/
 

--- a/test/json/any_json_helper.cpp
+++ b/test/json/any_json_helper.cpp
@@ -88,7 +88,7 @@ struct any_json_helper_t {
 
 BOOST_AUTO_TEST_CASE(any_json_helper_smoke) {
     std::cout << "-=-=- any_json_helper_smoke -=-=-\n";
-    any x = json_parser<any_json_helper_t>(u8R"raw(
+    any x = json_parser<any_json_helper_t>(reinterpret_cast<const char*>(u8R"raw(
         [
             42,
             12.536,
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(any_json_helper_smoke) {
                 "Country": "US"
             }
         ]
-    )raw")
+    )raw"))
                 .parse();
 
     json_generator<any_json_helper_t, ostream_iterator<char>>(ostream_iterator<char>(cout))

--- a/test/json/asl_json_helper.cpp
+++ b/test/json/asl_json_helper.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(asl_json_floating_point_parsing) {
 
 BOOST_AUTO_TEST_CASE(asl_json_helper_smoke) {
     std::cout << "-=-=- asl_json_helper_smoke -=-=-\n";
-    adobe::any_regular_t x = adobe::json_parse(u8R"raw(
+    adobe::any_regular_t x = adobe::json_parse(reinterpret_cast<const char*>(u8R"raw(
         [
             42,
             12.536,
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(asl_json_helper_smoke) {
                 "Country": "US"
             }
         ]
-    )raw");
+    )raw"));
 
     adobe::json_generate(x, std::ostream_iterator<char>(std::cout));
 }


### PR DESCRIPTION
My earlier attempt to fix build failures on MSVS 17.6 and C++20 caused build failures on Ubuntu + clang-11.
I have created a PR to revert those changes, https://github.com/stlab/adobe_source_libraries/pull/122

Instead of changing existing working code, I am proposing to use C++20 keyword `requires` to check if `<<` operator exists. With C++20 we can write a simpler check as following:
```
    if constexpr (requires { s << x; }) {
        s << x;
    }
```