### PR TITLE
Adding `iterator` to `string.cpp`

### DIFF
--- a/source/string.cpp
+++ b/source/string.cpp
@@ -14,6 +14,8 @@
 #include <array>
 #include <charconv>
 #include <system_error>
+#else
+#include <iterator>
 #endif
 
 /**************************************************************************************************/


### PR DESCRIPTION
When compiling without `to_chars` support enabled (that is, `__cpp_lib_to_chars >= 201611L` is `false`), `string.cpp` uses `std::back_inserter`, which requires `<iterator>` be included. This dependency is missing and causes some compilers to fail (e.g., Xcode 16.1 building under C++23). This PR adds the necessary include.