### PR TITLE
fix crasher in iomanip.hpp

### DIFF
--- a/adobe/iomanip.hpp
+++ b/adobe/iomanip.hpp
@@ -135,7 +135,7 @@ protected:
     stack_value_type& stack_top() { return stack_n(0); }
 
     const stack_value_type& stack_n(std::size_t n) const {
-        if (n > stack_m.size()) {
+        if (n >= stack_m.size()) {
             std::stringstream buf;
             buf << "stack_n: n(" << static_cast<unsigned int>(n) << ") > size("
                 << static_cast<unsigned int>(stack_m.size()) << ").";
@@ -146,7 +146,7 @@ protected:
     }
 
     stack_value_type& stack_n(std::size_t n) {
-        if (n > stack_m.size()) {
+        if (n >= stack_m.size()) {
             std::stringstream buf;
             buf << "stack_n: n(" << static_cast<unsigned int>(n) << ") > size("
                 << static_cast<unsigned int>(stack_m.size()) << ").";


### PR DESCRIPTION
off-by-one error checking for out-of-range error

The stack_n is crashing when it is dereferencing end.  (Potential crash.  UB, so who knows.)

Should be out-of-range checking for `n >= stack_m.size()`.  Crashing code is checking `n > stack_m.size()`.